### PR TITLE
Release #59

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -11,6 +11,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AppFooter: typeof import('./src/components/layout/AppFooter.vue')['default']
     AppFormField: typeof import('./src/components/AppFormField.vue')['default']
     AppHeading: typeof import('./src/components/AppHeading.vue')['default']
     AppLink: typeof import('./src/components/AppLink.vue')['default']

--- a/docs/prompts/tasks/task-059-add-a-footer/README.md
+++ b/docs/prompts/tasks/task-059-add-a-footer/README.md
@@ -1,0 +1,13 @@
+# Task 059 — Add a footer
+
+## Source
+
+GitHub Issue #59: https://github.com/JeremieLitzler/SocialMediaPublisherApp/issues/59
+
+## Request
+
+Add a footer to the application. It must contain:
+
+- A link to the blog with `href="https://iamjeremie.me/"` (`target="_blank"`) and the link text "Made by [Jeremie](https://iamjeremie.me/) and [Claude](https://claude.ai/code)"
+- A link to the license file of this repo (`target="_blank"`)
+- A link to Netlify with the text "Hosted on Netlify"

--- a/docs/prompts/tasks/task-059-add-a-footer/business-specifications.md
+++ b/docs/prompts/tasks/task-059-add-a-footer/business-specifications.md
@@ -1,0 +1,90 @@
+# Business Specifications — Task 059: Add a Footer
+
+## Goal and Scope
+
+Add a persistent application footer that appears on every page of the Social Media Publisher App. The footer provides attribution, licensing, and hosting information through three external links. It is purely informational and does not affect the article extraction or content generation workflows.
+
+## Context
+
+The current layout is a single-column, centered layout managed by `GuestLayout.vue`, which wraps the router view inside `App.vue`. The app already has an `AppLink.vue` component that handles both internal and external links, opening external links in a new tab with `rel="noopener"`. The footer must integrate into this existing layout structure.
+
+## Files to Create or Modify
+
+### Create: `src/components/layout/AppFooter.vue`
+
+A new layout component responsible for rendering the footer. It displays three external links. It is placed within the application layout so it is visible on all pages.
+
+### Modify: `src/components/layout/GuestLayout.vue`
+
+The existing guest layout wraps page content in a centered column. It must be updated to include the footer below the main page slot so the footer appears consistently on every page without being part of any individual page component.
+
+## Business Rules
+
+### Rule 1 — Footer is always visible
+
+The footer appears on every page of the application. It is not conditional on any application state (loading, error, success, idle).
+
+### Rule 2 — Three required links
+
+The footer must contain exactly three external links:
+
+1. **Author attribution link** — Links to `https://iamjeremie.me/` and opens in a new tab. The visible text must read: "Made by Jeremie and Claude". Both "Jeremie" and "Claude" are themselves hyperlinks within that text: "Jeremie" links to `https://iamjeremie.me/` and "Claude" links to `https://claude.ai/code`. Both open in a new tab.
+
+2. **License link** — Links to the LICENSE file of this repository on GitHub and opens in a new tab. The visible text must clearly communicate it is the project license.
+
+3. **Netlify hosting link** — Links to Netlify and opens in a new tab. The visible text must read "Hosted on Netlify".
+
+### Rule 3 — All footer links open in a new tab
+
+Every link in the footer is external. All must open in a new browser tab (`target="_blank"`) with `rel="noopener"` for security. The existing `AppLink.vue` component already handles this behaviour for any URL starting with `http`, so it is the appropriate component to use.
+
+### Rule 4 — Footer uses existing UI patterns
+
+The footer is styled consistently with the rest of the application. It uses Tailwind CSS utility classes, matching the visual conventions already present in layout components such as `NavBarTop.vue` (border, padding, flex layout).
+
+## Example Mapping
+
+### Feature: Footer always appears
+
+**Rule:** The footer is present on every page regardless of application state.
+
+- **Example:** When the app loads and the article input is shown (idle state), the footer is visible at the bottom of the page.
+- **Example:** When an article is successfully extracted and platform content is displayed, the footer is still visible at the bottom of the page.
+- **Example:** When an error occurs during article extraction, the footer is still visible at the bottom of the page.
+
+### Feature: Author attribution link
+
+**Rule:** The footer contains an inline attribution sentence where "Jeremie" and "Claude" are separate clickable links.
+
+- **Example:** A user sees the text "Made by Jeremie and Claude" in the footer. Clicking "Jeremie" opens `https://iamjeremie.me/` in a new tab. Clicking "Claude" opens `https://claude.ai/code` in a new tab.
+- **Example:** Both links open in a new tab without navigating away from the application.
+
+### Feature: License link
+
+**Rule:** The footer contains a link to the project license file.
+
+- **Example:** A user clicks the license link and is taken to the LICENSE file of this repository on GitHub in a new tab.
+
+### Feature: Netlify hosting link
+
+**Rule:** The footer contains a link to Netlify with the text "Hosted on Netlify".
+
+- **Example:** A user sees "Hosted on Netlify" in the footer and clicks it. The Netlify website opens in a new tab without navigating away from the application.
+
+### Feature: New-tab behaviour for all footer links
+
+**Rule:** All footer links are external and must not navigate away from the app.
+
+- **Example:** A user clicks any footer link. The application remains open in the current tab; the linked page opens in a new tab.
+
+## Edge Cases
+
+- **No JavaScript / link fallback:** If a user's browser does not open new tabs (e.g., popup blocker), the link still navigates to the correct URL in the current tab. The `rel="noopener"` attribute remains present regardless.
+- **Narrow viewport:** On small screen widths, the footer links must remain readable and not overflow their container. Wrapping is acceptable; horizontal scrolling is not.
+- **Long text wrap:** The attribution sentence "Made by Jeremie and Claude" contains two inline links. If the viewport is narrow enough to cause line wrapping within the sentence, the text remains coherent and the links remain individually clickable.
+
+### ADR Required
+
+The introduction of a dedicated footer component as part of `GuestLayout.vue` does not introduce a new architectural pattern (layout components already exist under `src/components/layout/`). No new ADR is needed.
+
+status: ready

--- a/docs/prompts/tasks/task-059-add-a-footer/technical-specifications.md
+++ b/docs/prompts/tasks/task-059-add-a-footer/technical-specifications.md
@@ -1,0 +1,24 @@
+# Technical Specifications — Task 059: Add a Footer
+
+## Files Created or Changed
+
+| File | Action | Description |
+|---|---|---|
+| `src/components/layout/AppFooter.vue` | Created | New footer layout component rendering three external links (author attribution, license, Netlify hosting). |
+| `src/components/layout/GuestLayout.vue` | Modified | Wrapped `<slot>` in a flex column container and added `<AppFooter />` below it so the footer appears on every page. |
+
+## Technical Choices
+
+### AppLink reuse
+`AppLink` is already auto-imported and handles external URLs by detecting `http` prefix, applying `target="_blank"` and `rel="noopener"` automatically. No custom anchor elements were needed.
+
+### GuestLayout restructure
+The original layout used a single `div` with `justify-center items-center` targeting both axes. To stack the slot content and the footer vertically, the outer div was changed to `flex-col`. The slot content is wrapped in its own inner div preserving the original horizontal centering behaviour.
+
+### Tailwind styling
+The footer uses `border-t flex flex-wrap justify-center items-center gap-4 px-4 py-3 text-sm`, consistent with the `border-b flex … items-center px-4` pattern from `NavBarTop.vue`. `flex-wrap` satisfies the narrow-viewport edge case from the business spec.
+
+### No new dependencies or ADRs
+No new libraries, stores, or architectural patterns were introduced. The footer is a stateless presentational component composed entirely from existing primitives.
+
+status: ready

--- a/docs/prompts/tasks/task-059-add-a-footer/test-results.md
+++ b/docs/prompts/tasks/task-059-add-a-footer/test-results.md
@@ -1,0 +1,66 @@
+# Test Results — Task 059: Add a Footer
+
+## Test Files Created
+
+| File | Tests |
+|---|---|
+| `src/components/layout/AppFooter.test.ts` | 10 tests |
+| `src/components/layout/GuestLayout.test.ts` | 9 tests |
+
+---
+
+## AppFooter — Results
+
+All 10 tests passed.
+
+| # | Test | Result |
+|---|---|---|
+| 1 | renders a `<footer>` element | PASS |
+| 2 | renders exactly four external anchor elements (Jeremie, Claude, License, Netlify) | PASS |
+| 3 | renders an AppLink pointing to `https://iamjeremie.me/` with text "Jeremie" | PASS |
+| 4 | renders an AppLink pointing to `https://claude.ai/code` with text "Claude" | PASS |
+| 5 | renders a license AppLink pointing to the GitHub LICENSE file | PASS |
+| 6 | renders an AppLink pointing to `https://www.netlify.com/` with text "Hosted on Netlify" | PASS |
+| 7 | all links have `target="_blank"` | PASS |
+| 8 | all links have `rel="noopener"` | PASS |
+| 9 | footer text contains "Made by" | PASS |
+| 10 | footer text contains "and" | PASS |
+
+### Note on link count
+
+The business specification describes "three required links" meaning three logical sections (attribution, license, hosting). The implementation correctly renders four `<a>` elements because the attribution section contains two inline hyperlinks — "Jeremie" and "Claude" — each linking to a distinct URL. The test was updated to assert four elements with a clarifying comment.
+
+---
+
+## GuestLayout — Results
+
+All 9 tests passed.
+
+| # | Test | Result |
+|---|---|---|
+| 1 | renders the slot content | PASS |
+| 2 | renders AppFooter below the slot content | PASS |
+| 3 | renders a `<footer>` element | PASS |
+| 4 | footer appears after slot content in the DOM | PASS |
+| 5 | renders AppFooter even when slot is empty | PASS |
+| 6 | renders AppFooter with different slot content (error state) | PASS |
+| 7 | renders AppFooter with different slot content (success state) | PASS |
+| 8 | root element has `layout-guest` class | PASS |
+| 9 | root element uses `flex-col` layout | PASS |
+
+---
+
+## Full Suite
+
+```
+Test Files  17 passed (17)
+      Tests 270 passed (270)
+   Start at 21:25:45
+   Duration 7.39s (transform 1.75s, setup 0ms, import 4.68s, tests 2.16s, environment 9.53s)
+```
+
+No regressions in previously passing tests.
+
+---
+
+status: passed

--- a/src/components/layout/AppFooter.test.ts
+++ b/src/components/layout/AppFooter.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AppFooter from './AppFooter.vue'
+import AppLink from '@/components/AppLink.vue'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div />' } }],
+})
+
+const globalConfig = {
+  global: {
+    plugins: [router],
+    components: { AppLink },
+  },
+}
+
+describe('AppFooter', () => {
+  it('renders a <footer> element', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    expect(wrapper.find('footer').exists()).toBe(true)
+  })
+
+  it('renders exactly four external anchor elements (Jeremie, Claude, License, Netlify)', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    const links = wrapper.findAll('a.external-link')
+    // Three logical sections: attribution (2 links: Jeremie + Claude), license, Netlify hosting
+    expect(links).toHaveLength(4)
+  })
+
+  it('renders an AppLink pointing to https://iamjeremie.me/ with text "Jeremie"', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    const jeremieLink = wrapper
+      .findAll('a.external-link')
+      .find((a) => a.attributes('href') === 'https://iamjeremie.me/')
+    expect(jeremieLink).toBeDefined()
+    expect(jeremieLink!.text()).toBe('Jeremie')
+  })
+
+  it('renders an AppLink pointing to https://claude.ai/code with text "Claude"', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    const claudeLink = wrapper
+      .findAll('a.external-link')
+      .find((a) => a.attributes('href') === 'https://claude.ai/code')
+    expect(claudeLink).toBeDefined()
+    expect(claudeLink!.text()).toBe('Claude')
+  })
+
+  it('renders a license AppLink pointing to the GitHub LICENSE file', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    const licenseLink = wrapper
+      .findAll('a.external-link')
+      .find((a) =>
+        a
+          .attributes('href')
+          ?.includes(
+            'https://github.com/JeremieLitzler/SocialMediaPublisherApp/blob/main/LICENSE',
+          ),
+      )
+    expect(licenseLink).toBeDefined()
+  })
+
+  it('renders an AppLink pointing to https://www.netlify.com/ with text "Hosted on Netlify"', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    const netlifyLink = wrapper
+      .findAll('a.external-link')
+      .find((a) => a.attributes('href') === 'https://www.netlify.com/')
+    expect(netlifyLink).toBeDefined()
+    expect(netlifyLink!.text()).toBe('Hosted on Netlify')
+  })
+
+  it('all links have target="_blank"', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    const links = wrapper.findAll('a.external-link')
+    links.forEach((link) => {
+      expect(link.attributes('target')).toBe('_blank')
+    })
+  })
+
+  it('all links have rel="noopener"', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    const links = wrapper.findAll('a.external-link')
+    links.forEach((link) => {
+      expect(link.attributes('rel')).toBe('noopener')
+    })
+  })
+
+  it('footer text contains "Made by"', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    expect(wrapper.find('footer').text()).toContain('Made by')
+  })
+
+  it('footer text contains "and"', () => {
+    const wrapper = mount(AppFooter, globalConfig)
+    expect(wrapper.find('footer').text()).toContain('and')
+  })
+})

--- a/src/components/layout/AppFooter.vue
+++ b/src/components/layout/AppFooter.vue
@@ -1,0 +1,16 @@
+<template>
+  <footer class="border-t flex flex-wrap justify-center items-center gap-4 px-4 py-3 text-sm">
+    <span>
+      Made by
+      <AppLink to="https://iamjeremie.me/">Jeremie</AppLink>
+      and
+      <AppLink to="https://claude.ai/code">Claude</AppLink>
+    </span>
+    <span>|</span>
+    <AppLink to="https://github.com/JeremieLitzler/SocialMediaPublisherApp/blob/main/LICENSE">
+      License
+    </AppLink>
+    <span>|</span>
+    <AppLink to="https://www.netlify.com/">Hosted on Netlify</AppLink>
+  </footer>
+</template>

--- a/src/components/layout/GuestLayout.test.ts
+++ b/src/components/layout/GuestLayout.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import GuestLayout from './GuestLayout.vue'
+import AppFooter from './AppFooter.vue'
+import AppLink from '@/components/AppLink.vue'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div />' } }],
+})
+
+const globalConfig = {
+  global: {
+    plugins: [router],
+    components: { AppFooter, AppLink },
+  },
+}
+
+describe('GuestLayout', () => {
+  it('renders the slot content', () => {
+    const wrapper = mount(GuestLayout, {
+      ...globalConfig,
+      slots: {
+        default: '<p id="slot-content">Page content</p>',
+      },
+    })
+    expect(wrapper.find('#slot-content').exists()).toBe(true)
+    expect(wrapper.find('#slot-content').text()).toBe('Page content')
+  })
+
+  it('renders AppFooter below the slot content', () => {
+    const wrapper = mount(GuestLayout, {
+      ...globalConfig,
+      slots: {
+        default: '<p id="slot-content">Page content</p>',
+      },
+    })
+    expect(wrapper.findComponent(AppFooter).exists()).toBe(true)
+  })
+
+  it('renders a <footer> element', () => {
+    const wrapper = mount(GuestLayout, {
+      ...globalConfig,
+      slots: {
+        default: '<p>Some page</p>',
+      },
+    })
+    expect(wrapper.find('footer').exists()).toBe(true)
+  })
+
+  it('footer appears after slot content in the DOM', () => {
+    const wrapper = mount(GuestLayout, {
+      ...globalConfig,
+      slots: {
+        default: '<p id="slot-content">Page content</p>',
+      },
+    })
+    const layoutDiv = wrapper.find('.layout-guest')
+    const children = layoutDiv.element.children
+    // The last child should be the footer
+    const lastChild = children[children.length - 1]
+    expect(lastChild.tagName.toLowerCase()).toBe('footer')
+  })
+
+  it('renders AppFooter even when slot is empty', () => {
+    const wrapper = mount(GuestLayout, globalConfig)
+    expect(wrapper.find('footer').exists()).toBe(true)
+  })
+
+  it('renders AppFooter with different slot content (error state)', () => {
+    const wrapper = mount(GuestLayout, {
+      ...globalConfig,
+      slots: {
+        default: '<div class="error-state">Error occurred</div>',
+      },
+    })
+    expect(wrapper.find('footer').exists()).toBe(true)
+    expect(wrapper.find('.error-state').exists()).toBe(true)
+  })
+
+  it('renders AppFooter with different slot content (success state)', () => {
+    const wrapper = mount(GuestLayout, {
+      ...globalConfig,
+      slots: {
+        default: '<div class="success-state">Article extracted</div>',
+      },
+    })
+    expect(wrapper.find('footer').exists()).toBe(true)
+    expect(wrapper.find('.success-state').exists()).toBe(true)
+  })
+
+  it('root element has layout-guest class', () => {
+    const wrapper = mount(GuestLayout, globalConfig)
+    expect(wrapper.find('.layout-guest').exists()).toBe(true)
+  })
+
+  it('root element uses flex-col layout', () => {
+    const wrapper = mount(GuestLayout, globalConfig)
+    const layoutDiv = wrapper.find('.layout-guest')
+    expect(layoutDiv.classes()).toContain('flex-col')
+  })
+})

--- a/src/components/layout/GuestLayout.vue
+++ b/src/components/layout/GuestLayout.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="layout-guest flex justify-center items-center mx-auto max-w-2xl">
-    <slot></slot>
+  <div class="layout-guest flex flex-col mx-auto max-w-2xl">
+    <div class="flex justify-center items-center">
+      <slot></slot>
+    </div>
+    <AppFooter />
   </div>
 </template>


### PR DESCRIPTION
* docs(specs): define specs for add a footer (#059)
* feat(layout): add persistent footer with attribution, license and hosting links (#59)
* chore: update auto-generated component types for AppFooter
* test(layout): add unit tests for AppFooter and GuestLayout footer integration (#59)
