### PR TITLE
ci(agent): add security and reviewer agents to the pipeline

### DIFF
--- a/.agents-brain/agent-0-orchestrator.md
+++ b/.agents-brain/agent-0-orchestrator.md
@@ -38,7 +38,19 @@ If the spec file contains `### ADR Required`, pause the pipeline and use AskUser
 Use AskUserQuestion to show the user a summary of `[task-folder]/business-specifications.md` and ask for approval before proceeding to commit changes.
 If the user does not approve, stop the pipeline and report why.
 
-Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3 only** (commit specs output). Then proceed to coding.
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3 only** (commit specs output). Then proceed to Step 1.5.
+
+### Step 1.5 — Security
+
+Read `.agents-brain/agent-5-security.md` and spawn a subagent using the Task tool with that prompt. Pass the task folder path `[task-folder]` to the subagent.
+
+The subagent reads `[task-folder]/business-specifications.md` and writes `[task-folder]/security-guidelines.md`.
+
+Wait for `[task-folder]/security-guidelines.md` to end with `status: ready`.
+
+If the file contains `### ADR Required`, pause the pipeline and use AskUserQuestion to present the ADR details to the user. The human must approve the ADR before coding starts. If the user does not approve, stop the pipeline and report why.
+
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3.5 only** (commit security guidelines). Then proceed to coding.
 
 ### Step 2 — Coding
 
@@ -55,12 +67,27 @@ If `status: review specs`:
 - Inform the user and re-run Step 1 (counts toward MAX_RETRIES).
 - On approval, retry Step 2.
 
-If `status: ready`:
+If `status: ready`, proceed to Step 2.5.
 
-- If the technical-spec file contains `### ADR Required`, pause the pipeline and use AskUserQuestion to present the ADR details to the user. The human must approve the ADR before committing code. If the user does not approve, stop the pipeline.
+### Step 2.5 — Code Review
+
+Read `.agents-brain/agent-6-reviewer.md` and spawn a subagent using the Task tool with that prompt. Pass the task folder path `[task-folder]` to the subagent.
+
+The subagent reviews the changed source files against `[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`, runs `npm run lint` and `npm run type-check`, and writes `[task-folder]/review-results.md`.
+
+Wait for `[task-folder]/review-results.md` to end with either `status: approved` or `status: changes requested`.
+
+If `status: changes requested`:
+
+- Re-run Step 2 (coder reads `review-results.md` and fixes). Counts toward MAX_RETRIES.
+- Then re-run Step 2.5.
+
+If `status: approved`:
+
+- If `[task-folder]/technical-specifications.md` contains `### ADR Required`, pause the pipeline and use AskUserQuestion to present the ADR details to the user. The human must approve the ADR before committing code. If the user does not approve, stop the pipeline.
 - Use AskUserQuestion to show the user a summary of `[task-folder]/technical-specifications.md` and ask for approval before testing.
   - If the user does not approve, stop the pipeline.
-- Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 4 only** (commit code changes).
+- Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 4 only** (commit code and review changes).
 
 ### Step 3 — Testing
 

--- a/.agents-brain/agent-2-coder.md
+++ b/.agents-brain/agent-2-coder.md
@@ -1,6 +1,6 @@
 # I am a Coder Agent
 
-Read the business spec at `[task-folder]/business-specifications.md` passed by the orchestrator and implement exactly what is specified.
+Read the business spec at `[task-folder]/business-specifications.md` and the security guidelines at `[task-folder]/security-guidelines.md` passed by the orchestrator. Implement exactly what is specified in the business spec and enforce every rule in the security guidelines.
 
 Follow the architecture described in CLAUDE.md. Do not add features beyond the spec.
 

--- a/.agents-brain/agent-4-git.md
+++ b/.agents-brain/agent-4-git.md
@@ -57,11 +57,21 @@ feat(specs): define specs for [short description](#[issue id])
 
 Do not push yet.
 
+### Task 3.5: Commit security guidelines
+
+Stage `[task-folder]/security-guidelines.md` (path passed by orchestrator) and commit it on the current branch with a short message such as:
+
+```plaintext
+feat(security): add security guidelines for [short description](#[issue id])
+```
+
+Do not push yet.
+
 ### Task 4: Commit code changes
 
 Read `[task-folder]/technical-specifications.md` (passed by orchestrator) for the list of files changed.
 
-Stage those source files plus `[task-folder]/technical-specifications.md` and commit on the current branch with a message summarising the implementation based on `[task-folder]/business-specifications.md`. Do not push yet.
+Stage those source files plus `[task-folder]/technical-specifications.md` and `[task-folder]/review-results.md` and commit on the current branch with a message summarising the implementation based on `[task-folder]/business-specifications.md`. Do not push yet.
 
 ### Task 5: Commit test results and push
 

--- a/.agents-brain/agent-5-security.md
+++ b/.agents-brain/agent-5-security.md
@@ -1,0 +1,38 @@
+# I am a Security Agent
+
+Read the business spec at `[task-folder]/business-specifications.md` passed by the orchestrator. Produce security guidelines for the coder based on the project's technology stack (Vue 3, TypeScript, Vite, Netlify Functions) and architecture described in CLAUDE.md.
+
+## Scope of analysis
+
+- Input validation and sanitisation rules relevant to the feature (URL inputs, user-supplied strings, DOM parsing via `DOMParser`)
+- Output encoding risks (XSS surface in generated HTML or content rendered in the UI)
+- Netlify Function boundary concerns: request validation, domain allowlist enforcement, response shape handling
+- Dependency risks introduced by the change (new packages, external resources)
+- Secrets and environment variable handling
+- CORS and HTTP header concerns specific to the change
+
+## Writing the security-guidelines file
+
+Write `[task-folder]/security-guidelines.md` as a numbered list of actionable rules for the coder.
+
+Each rule must state:
+
+- **What** must be enforced
+- **Where** (which file or layer it applies to)
+- **Why** (the attack vector or risk it mitigates)
+
+Do NOT prescribe implementation details. No function signatures, no code snippets, no variable names. State the constraint and the reason.
+
+## ADR Requirements
+
+If the guidelines introduce a new security pattern not yet documented in `docs/decisions/`, add the following section before the final status line:
+
+```
+### ADR Required
+
+[Description of the new security pattern and why it is needed]
+```
+
+Notify the orchestrator so it can pause the pipeline and ask the human to approve the ADR before coding starts.
+
+End the file with `status: ready` as the last line.

--- a/.agents-brain/agent-6-reviewer.md
+++ b/.agents-brain/agent-6-reviewer.md
@@ -1,0 +1,72 @@
+# I am a Code Reviewer Agent
+
+Read the following files passed by the orchestrator:
+
+- `[task-folder]/technical-specifications.md` — to know which source files were changed
+- `[task-folder]/security-guidelines.md` — to verify every security rule was addressed
+- `[task-folder]/business-specifications.md` — to verify the implementation matches expected behaviour
+
+Then read every source file listed in the technical spec.
+
+Run `npm run lint` and `npm run type-check` from the repository root. Include their full output in your findings.
+
+Before reviewing Vue/TypeScript-specific issues, fetch the following reference pages to ground your review in current documentation:
+
+- `https://vuejs.org/guide/essentials/reactivity-fundamentals` — reactivity model
+- `https://vuejs.org/guide/reusability/composables` — composable conventions
+- `https://vuejs.org/guide/typescript/composition-api` — TypeScript + Vue patterns
+- `https://developer.mozilla.org/en-US/docs/Web/API/URL` — URL API (used in `utm.ts`)
+
+## Review checklist
+
+- Every rule in `[task-folder]/security-guidelines.md` is verifiably addressed in the changed files
+- Object Calisthenics rules are respected (as defined in `agent-2-coder.md`)
+- The implementation matches the business spec — no missing requirements, no scope creep
+- No dead code, unused imports, or unreachable branches
+- Naming clarity — no abbreviations, intent is obvious:
+  - Violations: `btn` → `submitButton`, `idx` → `index`, `val` → `extractedValue`, `res` → `fetchResponse`, `err` → `error`, `cb` → `onSuccessCallback`, `fn` → `transformContent`
+  - Single-letter loop variables outside trivial math: `for (const i of items)` → `for (const item of items)`
+- Vue/TypeScript-specific issues:
+
+  Reactivity pitfalls:
+  - Destructuring a reactive object loses reactivity: `const { title } = useArticleState()` silently breaks; use `toRefs()` or access as `state.title`
+  - Watching a reactive property directly: `watch(state.count, ...)` never triggers; use a getter `watch(() => state.count, ...)`
+  - Mutating a prop in-place instead of emitting an event
+  - Calling `reactive()` on a primitive value
+
+  Type safety:
+  - Using `any` or `unknown` without a narrowing guard
+  - Non-null assertions (`!`) without a preceding null check
+  - Untyped function parameters that implicitly become `any`
+  - Missing explicit return types on exported functions
+
+  Composable conventions:
+  - A composable not prefixed with `use`
+  - A composable accepting a reactive argument without normalising it via `toValue()` or `toRef()`
+  - Side effects (event listeners, timers, subscriptions) set up without a matching `onUnmounted` cleanup
+
+## Writing the review-results file
+
+Create `[task-folder]/review-results.md`.
+
+Include the full output of `npm run lint` and `npm run type-check`.
+
+If findings exist, list every finding with:
+
+- File path and line reference
+- Which checklist rule it violates
+- A fix direction (no code)
+
+End with:
+
+```plaintext
+status: changes requested
+```
+
+If no findings remain, write a brief summary of what was reviewed. End with:
+
+```plaintext
+status: approved
+```
+
+The status line must always be the last line of the file.

--- a/CLAUDE-AGENT-ADDITIONS-2026-03-05.md
+++ b/CLAUDE-AGENT-ADDITIONS-2026-03-05.md
@@ -1,0 +1,211 @@
+# Agent Additions — 2026-03-05
+
+## Request
+
+Add two new agents to the multi-agent pipeline:
+
+1. **Security Agent** — reads business specs and produces security guidelines for the coder.
+2. **Code Reviewer Agent** — reviews coder output and loops with the coder until the review is clean.
+
+---
+
+## Proposed Agent Definitions
+
+### agent-5-security.md
+
+**Role:** Read `[task-folder]/business-specifications.md` and produce `[task-folder]/security-guidelines.md`.
+
+**Scope of analysis:**
+
+- Input validation and sanitisation rules relevant to the feature (URL inputs, user-supplied strings, etc.)
+- Output encoding risks (XSS surface in generated HTML/content)
+- Netlify Function boundary concerns: request validation, domain allowlist, response handling
+- Dependency risks related to the change (new packages, CDN resources)
+- Secrets and environment variable handling
+- CORS and HTTP header concerns specific to the change
+
+**Output format:** A numbered list of actionable security rules for the coder. Each rule must state:
+
+- What must be enforced
+- Where (which file or layer)
+- Why (attack vector or risk mitigated)
+
+**End marker:** `status: ready`
+
+**Placement in pipeline:** After specs commit, before coding. Coder reads `security-guidelines.md` alongside `business-specifications.md`.
+
+---
+
+### agent-6-reviewer.md
+
+**Role:** Review code produced by the coder and loop with it until the review is clean.
+
+**Scope of review:**
+
+- Compliance with `[task-folder]/security-guidelines.md` — every rule must be verifiably addressed
+- Compliance with Object Calisthenics rules from `agent-2-coder.md`
+- Adherence to the business spec (no missing requirements, no scope creep)
+- Dead code, unused imports, unreachable branches
+- Naming clarity (no abbreviations, intent is obvious)
+
+  Examples of violations:
+  - `btn` → `submitButton`, `idx` → `index`, `val` → `extractedValue`, `res` → `fetchResponse`, `err` → `error`, `cb` → `onSuccessCallback`, `fn` → `transformContent`
+  - Single-letter loop variables outside trivial math: `for (const i of items)` → `for (const item of items)`
+
+- Vue/TypeScript-specific issues: reactivity pitfalls, type safety, composable conventions
+
+  Examples of reactivity pitfalls:
+  - Destructuring a reactive object loses reactivity: `const { title } = useArticleState()` silently breaks; use `toRefs()` or access as `state.title`
+  - Watching a reactive property directly: `watch(state.count, ...)` never triggers; use a getter `watch(() => state.count, ...)`
+  - Mutating a prop in-place instead of emitting an event
+  - Calling `reactive()` on a primitive value (returns the value unchanged)
+
+  Examples of type safety violations:
+  - Using `any` or `unknown` without a narrowing guard
+  - Non-null assertions (`!`) applied without a preceding null check
+  - Untyped function parameters that implicitly become `any`
+  - Missing explicit return types on exported functions
+
+  Examples of composable convention violations:
+  - A composable not prefixed with `use` (e.g. `getArticleState`)
+  - A composable accepting a reactive argument without normalising it via `toValue()` or `toRef()`
+  - Side effects (event listeners, timers, subscriptions) set up in the composable body without a matching `onUnmounted` cleanup
+
+**Loop behaviour:**
+
+- If findings exist: write `[task-folder]/review-results.md` ending with `status: changes requested`, listing every finding with file + line reference and a suggested fix direction (not code).
+- Coder reads the review, fixes, re-writes `[task-folder]/technical-specifications.md`, ends with `status: ready`.
+- Reviewer re-runs. Loop continues until reviewer writes `status: approved`.
+- Each loop iteration counts toward `MAX_RETRIES`.
+
+**Output file:** `[task-folder]/review-results.md`
+
+**End markers:** `status: approved` or `status: changes requested`
+
+**Placement in pipeline:** After coding, before human approval and testing.
+
+---
+
+## Proposed Pipeline Changes
+
+### agent-0-orchestrator.md
+
+Insert two new steps:
+
+**After Step 1 (specs commit), before Step 2 (coding):**
+
+```
+### Step 1.5 — Security
+
+Read `.agents-brain/agent-5-security.md` and spawn a subagent. Pass `[task-folder]`.
+
+The subagent reads `[task-folder]/business-specifications.md` and writes `[task-folder]/security-guidelines.md`.
+
+Wait for `status: ready`. On failure, stop and report.
+```
+
+**After Step 2 (coding), before human approval:**
+
+```
+### Step 2.5 — Code Review
+
+Read `.agents-brain/agent-6-reviewer.md` and spawn a subagent. Pass `[task-folder]`.
+
+The subagent reviews source files listed in `[task-folder]/technical-specifications.md` against
+`[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`.
+
+Wait for `[task-folder]/review-results.md` to end with `status: approved` or `status: changes requested`.
+
+If `status: changes requested`:
+- Re-run Step 2 (coder reads review-results.md and fixes). Counts toward MAX_RETRIES.
+- Then re-run Step 2.5.
+
+If `status: approved`:
+- Proceed to human approval, then commit code (Task 4).
+```
+
+### CLAUDE.md
+
+Add agents 5 and 6 to the agents table and update the pipeline flow diagram:
+
+| Agent    | Prompt                              | Reads                                                                               | Writes                                 |
+| -------- | ----------------------------------- | ----------------------------------------------------------------------------------- | -------------------------------------- |
+| Security | `.agents-brain/agent-5-security.md` | `[task-folder]/business-specifications.md`                                          | `[task-folder]/security-guidelines.md` |
+| Reviewer | `.agents-brain/agent-6-reviewer.md` | `[task-folder]/technical-specifications.md`, `[task-folder]/security-guidelines.md` | `[task-folder]/review-results.md`      |
+
+Updated pipeline flow:
+
+```plaintext
+[task-folder]/README.md
+       ↓
+Versioning agent → branch
+       ↓
+  Specs agent → business-specifications.md
+       ↓           ↑ ADR Required (human approves before proceeding)
+Versioning agent → commit specs
+       ↓ ← human approval
+Security agent → security-guidelines.md
+       ↓
+  Coder agent → technical-specifications.md (reads security-guidelines.md)
+       ↓           ↑ status: review specs (loops back to specs)
+Reviewer agent → review-results.md
+       ↓           ↑ status: changes requested (loops back to coder)
+       ↓           ↑ ADR Required (human approves before committing)
+Versioning agent → commit code
+       ↓ ← human approval
+ Tester agent → test-results.md
+       ↓           ↑ status: failed (loops back to coder)
+Versioning agent → commit tests + push
+       ↓ ← human approval (PR creation)
+  gh pr create
+       ↓ ← human approval (merge)
+  gh pr merge
+```
+
+Convert workflow to flowchart diagram with mermaid.
+
+### Task folder structure (updated)
+
+```
+docs/prompts/tasks/
+  issue-[id of issue]-[slug]/
+    README.md                    ← user request (input)
+    business-specifications.md   ← specs agent output
+    security-guidelines.md       ← security agent output
+    technical-specifications.md  ← coder agent output
+    review-results.md            ← reviewer agent output
+    test-results.md              ← tester agent output
+```
+
+---
+
+## Documentation Lookup in the Reviewer Agent
+
+### Option A — Context7 MCP (not implemented)
+
+Context7 is an MCP server (`npx -y @upstash/context7-mcp`) that provides version-pinned, structured library documentation via a dedicated tool call. The reviewer agent would resolve library IDs (e.g. `vue`, `mdn`) and receive curated doc snippets at review time.
+
+Not configured for this project. Would require adding a `.mcp.json` at the repository root and registering the server in Claude project settings. Chosen against for now to avoid external service dependency.
+
+For MDN, the question is: which source is better from the top 4 sources: https://context7.com/?q=mdn
+For Vue.js, a decision is needed to pick the source(s): https://context7.com/?q=vue
+
+### Option B — WebFetch on canonical URLs (implemented)
+
+The reviewer agent fetches specific Vue 3 and MDN reference pages directly via `WebFetch` when checking reactivity, composable, or Web API patterns. No setup required.
+
+Pages anchored in `agent-6-reviewer.md`:
+
+- `https://vuejs.org/guide/essentials/reactivity-fundamentals` — reactivity model
+- `https://vuejs.org/guide/reusability/composables` — composable conventions
+- `https://vuejs.org/guide/typescript/composition-api` — TypeScript + Vue
+- `https://developer.mozilla.org/en-US/docs/Web/API/URL` — URL API (used in `utm.ts`)
+
+---
+
+## Open Questions (resolve before writing agent files)
+
+1. Should the security agent also flag ADR-Required if a new security pattern is introduced? Yes.
+2. Should `review-results.md` be committed separately (new versioning task), or included with the code commit (Task 4)? included with the code commit.
+3. Should the reviewer have access to run `npm run lint` / `npm run type-check` directly, or is it read-only? access to run `npm run lint` / `npm run type-check` directly.
+4. Should `security-guidelines.md` be committed alongside `business-specifications.md` (Task 3), or in a new Task 3.5? new Task 3.5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,9 @@ docs/prompts/tasks/
   issue-[id of issue]-[slug]/
     README.md                    ← user request (input)
     business-specifications.md   ← specs agent output
+    security-guidelines.md       ← security agent output
     technical-specifications.md  ← coder agent output
+    review-results.md            ← reviewer agent output
     test-results.md              ← tester agent output
 ```
 
@@ -136,36 +138,45 @@ docs/prompts/tasks/
 
 ### Agents and their prompt files
 
-| Agent         | Prompt                            | Reads                                                                                   | Writes                                      |
-| ------------- | --------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------- |
-| Specification | `.agents-brain/agent-1-specs.md`  | `[task-folder]/README.md`                                                               | `[task-folder]/business-specifications.md`  |
-| Coder         | `.agents-brain/agent-2-coder.md`  | `[task-folder]/business-specifications.md`                                              | `[task-folder]/technical-specifications.md` |
-| Tester        | `.agents-brain/agent-3-tester.md` | `[task-folder]/business-specifications.md`, `[task-folder]/technical-specifications.md` | `[task-folder]/test-results.md`             |
-| Versioning    | `.agents-brain/agent-4-git.md`    | `[task-folder]/business-specifications.md`, `[task-folder]/test-results.md`             | git history                                 |
+| Agent         | Prompt                               | Reads                                                                                                          | Writes                                          |
+| ------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| Specification | `.agents-brain/agent-1-specs.md`     | `[task-folder]/README.md`                                                                                      | `[task-folder]/business-specifications.md`      |
+| Security      | `.agents-brain/agent-5-security.md`  | `[task-folder]/business-specifications.md`                                                                     | `[task-folder]/security-guidelines.md`          |
+| Coder         | `.agents-brain/agent-2-coder.md`     | `[task-folder]/business-specifications.md`, `[task-folder]/security-guidelines.md`                            | `[task-folder]/technical-specifications.md`     |
+| Reviewer      | `.agents-brain/agent-6-reviewer.md`  | `[task-folder]/technical-specifications.md`, `[task-folder]/security-guidelines.md`, `[task-folder]/business-specifications.md` | `[task-folder]/review-results.md` |
+| Tester        | `.agents-brain/agent-3-tester.md`    | `[task-folder]/business-specifications.md`, `[task-folder]/technical-specifications.md`                       | `[task-folder]/test-results.md`                 |
+| Versioning    | `.agents-brain/agent-4-git.md`       | `[task-folder]/business-specifications.md`, `[task-folder]/test-results.md`                                   | git history                                     |
 
 ### Pipeline flow
 
-```
-[task-folder]/README.md
-       ↓
-Versioning agent → branch
-       ↓
-  Specs agent → business-specifications.md
-       ↓           ↑ ADR Required (human approves before proceeding)
-Versioning agent → commit specs
-       ↓ ← human approval
-  Coder agent → technical-specifications.md
-       ↓           ↑ status: review specs (loops back)
-       ↓           ↑ ADR Required (human approves before committing)
-Versioning agent → commit code
-       ↓ ← human approval
- Tester agent → test-results.md
-       ↓           ↑ status: failed (loops back to coder)
-Versioning agent → commit tests + push
-       ↓ ← human approval (PR creation)
-  gh pr create
-       ↓ ← human approval (merge)
-  gh pr merge
+```mermaid
+flowchart TD
+    userRequest([User request<br />docs/prompts/tasks/issue-&lsqb;id&rsqb;-&lsqb;slug&rsqb;/README.md]) --> versioningBranch[Versioning agent<br />Task 1-2: pull develop + create branch]
+    versioningBranch --> specsAgent[Specs agent<br />writes business-specifications.md]
+    specsAgent -->|ADR Required → human approves| specsAgent
+    specsAgent --> approveSpecs{Human approves<br />business specs?}
+    approveSpecs -->|Rejected| stoppedAfterSpecs([Pipeline stopped])
+    approveSpecs -->|Approved| versioningCommitSpecs[Versioning agent<br />Task 3: commit business-specifications.md]
+    versioningCommitSpecs --> securityAgent[Security agent<br />writes security-guidelines.md]
+    securityAgent -->|ADR Required → human approves| securityAgent
+    securityAgent --> versioningCommitSecurity[Versioning agent<br />Task 3.5: commit security-guidelines.md]
+    versioningCommitSecurity --> coderAgent[Coder agent<br />writes technical-specifications.md]
+    coderAgent -->|status: review specs → loop back| specsAgent
+    coderAgent --> reviewerAgent[Reviewer agent<br />runs lint + type-check + writes review-results.md]
+    reviewerAgent -->|status: changes requested → loop back| coderAgent
+    reviewerAgent -->|ADR Required → human approves| reviewerAgent
+    reviewerAgent --> approveTechnicalSpecs{Human approves<br />technical specs?}
+    approveTechnicalSpecs -->|Rejected| stoppedAfterReview([Pipeline stopped])
+    approveTechnicalSpecs -->|Approved| versioningCommitCode[Versioning agent<br />Task 4: commit source files + review-results.md]
+    versioningCommitCode --> testerAgent[Tester agent<br />runs npm test + writes test-results.md]
+    testerAgent -->|status: failed → loop back| coderAgent
+    testerAgent --> versioningCommitTests[Versioning agent<br />Task 5: commit test files + push branch]
+    versioningCommitTests --> approvePR{Human approves<br />PR creation?}
+    approvePR -->|Rejected| stoppedBeforePR([Pipeline stopped])
+    approvePR -->|Approved| createPR[gh pr create]
+    createPR --> approveMerge{Human approves<br />merge?}
+    approveMerge -->|Rejected| prRemainsOpen([PR remains open])
+    approveMerge -->|Approved| mergePR([gh pr merge + return to develop])
 ```
 
 Human approval gates: after specs, after coding, before PR creation, and before merge. The orchestrator retries failed loops up to 3 times before aborting. Agents flag `### ADR Required` in their output files when a new architectural pattern is introduced; the orchestrator surfaces this to the human before proceeding.


### PR DESCRIPTION
## Summary

- Add **agent-5-security.md**: a new Security agent that analyses code changes for vulnerabilities and produces a `security-guidelines.md` artifact per task.
- Add **agent-6-reviewer.md**: a new Code Reviewer agent that checks implementation quality and produces a `review-results.md` artifact per task.
- Update **agent-0-orchestrator.md**: inserted Step 1.5 (Security) after specs and Step 2.5 (Code Review) after coding in the pipeline flow.
- Update **agent-2-coder.md**: coder now reads `security-guidelines.md` before writing technical specs.
- Update **agent-4-git.md**: added Task 3.5 to commit security guidelines; updated Task 4 to also stage `review-results.md`.
- Update **CLAUDE.md**: agents table updated with two new rows, pipeline flow section replaced with a Mermaid diagram, task folder structure updated to include new artifact files.
- Add **CLAUDE-AGENT-ADDITIONS-2026-03-05.md**: design notes documenting the rationale and decisions behind the two new agents.

## Test plan

- [x] Verify `agent-5-security.md` and `agent-6-reviewer.md` exist and are well-formed in `.agents-brain/`
- [x] Confirm `CLAUDE.md` agents table lists all six agents correctly
- [x] Confirm `CLAUDE.md` pipeline flow renders as a valid Mermaid diagram
- [x] Confirm `agent-0-orchestrator.md` references Step 1.5 and Step 2.5 in the correct order
- [x] Confirm `agent-4-git.md` Task 3.5 and Task 4 reference `security-guidelines.md` and `review-results.md` respectively
- [x] Review `CLAUDE-AGENT-ADDITIONS-2026-03-05.md` for completeness of design notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)