### PR TITLE
fix(x-content): preserve paragraphs as chunk boundaries (#52)

### DIFF
--- a/.agents-brain/agent-1-specs.md
+++ b/.agents-brain/agent-1-specs.md
@@ -27,6 +27,8 @@ Do NOT include any of the following in a spec:
 
 ## ADR Requirements
 
+Use AWS's definition: "An Architecture Decision Record (ADR) is a short, structured text document that captures a significant,, high-impact architectural choice in software development, along with its context, rationale, and consequences. ADRs help teams track, communicate, and justify decisions (e.g., using microservices) to prevent knowledge loss and, when accepted, become an immutable part of the project's historical, audit-friendly log.". In doubt, Ask human for confirmation.
+
 If the spec introduces a new architectural pattern not yet documented in `docs/decisions/`, add the following section to the spec file before the final status line:
 
 ```

--- a/auto-imports.d.ts
+++ b/auto-imports.d.ts
@@ -134,6 +134,6 @@ declare global {
   export type { SideBarLinkAction } from './src/types/SideBarLinkAction'
   import('./src/types/SideBarLinkAction')
   // @ts-ignore
-  export type { ArticleURL, Blog, Platform, Article, ExtractionStatus, ExtractionState, XContent, LinkedInContent, MediumContent, SubstackContent, UTMParams } from './src/types/article'
+  export type { ArticleURL, Blog, Platform, Article, ExtractionStatus, ExtractionState, XChunk, XContent, LinkedInContent, MediumContent, SubstackContent, UTMParams } from './src/types/article'
   import('./src/types/article')
 }

--- a/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/README.md
+++ b/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/README.md
@@ -1,0 +1,26 @@
+# Issue 52 — Chunks not calculated properly on X content
+
+## User Request
+
+Resolve issue 52: chunks not calculated properly on X content.
+
+## Issue Details
+
+**URL:** https://github.com/JeremieLitzler/SocialMediaPublisherApp/issues/52
+**Label:** bug
+
+## Article URL (for reproduction)
+
+https://jeremielitzler.fr/post/2026-03/fonctions-d-ordre-superieur-en-javascript
+
+## Problem
+
+The description (introduction) contains two separate HTML `<p>` paragraphs, but they are being merged into a single chunk instead of being treated as two separate chunks.
+
+## Clarified Requirements
+
+1. Preserve paragraphs: one paragraph = one chunk.
+2. If a single paragraph is too long (>280 chars), chunk it at the first ".", "!", or "?" sentence boundary.
+3. If a long paragraph cannot be chunked by rule 2 (no sentence boundary found), display a warning to the user:
+   - Orange border on the chunk
+   - Warning message underneath the chunk (the warning message is NOT to be copied with the chunk content)

--- a/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/business-specifications.md
+++ b/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/business-specifications.md
@@ -1,0 +1,119 @@
+# Business Specifications — Issue 52: Chunks Not Calculated Properly on X Content
+
+## Context
+
+When an article introduction contains multiple HTML `<p>` paragraphs, the current X content generator merges them into a single plain text string before chunking. This causes distinct paragraphs to be collapsed together, producing incorrect chunk boundaries. The fix must preserve paragraph structure as the primary chunking unit.
+
+## Rules
+
+### Rule 1 — Paragraph-first chunking
+
+Each HTML `<p>` paragraph in the article introduction is treated as an independent unit. One paragraph produces one or more chunks, never fewer.
+
+No content from paragraph A can appear in the same chunk as content from paragraph B.
+
+### Rule 2 — Long paragraph splitting at sentence boundaries
+
+If a paragraph's plain text exceeds 280 characters, it is split into multiple chunks by accumulating sentences until the next sentence would push the chunk over 280 characters. Sentence boundaries are detected at `. ` (period-space), `! ` (exclamation-space), and `? ` (question-space).
+
+The chunk is emitted when the next sentence would exceed 280 characters, and a new chunk starts with that next sentence. This continues until all sentences of the paragraph have been placed.
+
+### Rule 3 — Oversized paragraph with no sentence boundary
+
+If a paragraph exceeds 280 characters and contains no sentence boundary (`. `, `! `, `? `), the entire paragraph becomes a single chunk and that chunk is marked with an oversized warning flag.
+
+### Rule 4 — Visual display of oversized chunk warning
+
+A chunk that carries an oversized warning flag must be displayed with:
+
+- An orange border (`border-orange-500`) surrounding the chunk card.
+- A warning message rendered below the chunk text content, inside the chunk card.
+
+The warning message text is: "This chunk exceeds 280 characters and could not be split. Consider adapting it before posting."
+
+The warning message is informational only. It is excluded from what is copied when the user activates the copy action for that chunk.
+
+### Rule 5 — Unchanged formatting rules for non-oversized chunks
+
+All existing formatting behaviour remains in place:
+
+- Every chunk except the last receives a downward arrow appended after its content.
+- The last chunk receives a triple downward arrow followed by the UTM-tagged article link appended after its content.
+- These appended elements are part of the copyable chunk text.
+
+### Rule 6 — Chunk count label calls out oversized chunks
+
+The chunk count label displayed to the user must distinguish oversized chunks from normal chunks. For example: "4 chunks to post, 1 oversized".
+
+If no chunks are oversized, only the total is shown: "4 chunks to post".
+
+## Examples
+
+### Example 1 — Two short paragraphs, each fits in one chunk
+
+**Given** an introduction with two `<p>` elements, each 120 characters long.
+
+**When** X content is generated.
+
+**Then** two chunks are produced: one per paragraph. The first chunk ends with the downward arrow. The second chunk ends with the triple arrow and the UTM link. The chunk count label reads "2 chunks to post".
+
+### Example 2 — One paragraph that fits within 280 characters
+
+**Given** an introduction with a single `<p>` element whose plain text is 200 characters.
+
+**When** X content is generated.
+
+**Then** one chunk is produced containing the paragraph text plus the triple arrow and UTM link. The chunk count label reads "1 chunk to post".
+
+### Example 3 — One long paragraph split at sentence boundaries
+
+**Given** an introduction with a single `<p>` element whose plain text is 420 characters containing three sentences separated by `. `.
+
+**When** X content is generated.
+
+**Then** the paragraph is split across two chunks. The first chunk accumulates sentences until the next would exceed 280 characters. The second chunk holds the remaining sentences. No oversized flag is set on either chunk. The chunk count label reads "2 chunks to post".
+
+### Example 4 — Long paragraph with no sentence boundary
+
+**Given** an introduction with a single `<p>` element whose plain text is 350 characters and contains no `. `, `! `, or `? ` sequence.
+
+**When** X content is generated.
+
+**Then** one chunk is produced with the full 350-character text and an oversized warning flag. The chunk card displays an orange border (`border-orange-500`) and the warning message "This chunk exceeds 280 characters and could not be split. Consider adapting it before posting." below the chunk text. Copying the chunk copies only the chunk text (plus the UTM arrow/link), not the warning message. The chunk count label reads "1 chunk to post, 1 oversized".
+
+### Example 5 — Mixed paragraphs: one short, one long with boundary, one oversized
+
+**Given** an introduction with three `<p>` elements:
+- Paragraph 1: 150 characters, no splitting needed.
+- Paragraph 2: 400 characters, contains two `. ` boundaries producing two sub-chunks.
+- Paragraph 3: 310 characters, no sentence boundary, requires an oversized flag.
+
+**When** X content is generated.
+
+**Then** four chunks are produced in order: chunk from paragraph 1, two chunks from paragraph 2, one oversized chunk from paragraph 3. The last chunk (from paragraph 3) carries the triple arrow and UTM link, plus the oversized warning flag. Chunks from paragraph 1 and the first sub-chunk of paragraph 2 carry the downward arrow. The chunk count label reads "4 chunks to post, 1 oversized".
+
+### Example 6 — Empty introduction
+
+**Given** an introduction with no `<p>` elements or an empty introduction string.
+
+**When** X content is generated.
+
+**Then** zero chunks are produced.
+
+### Example 7 — Warning message is not copied
+
+**Given** an oversized chunk (Rule 3) is displayed with its warning message.
+
+**When** the user activates the copy action for that chunk.
+
+**Then** only the chunk text (and its arrow/UTM suffix) is placed in the clipboard. The warning message text is not included.
+
+### Example 8 — UTM link on last oversized chunk
+
+**Given** an introduction where the last chunk produced is oversized.
+
+**When** X content is generated.
+
+**Then** the last chunk carries both the triple arrow + UTM link and the oversized warning flag. Both apply simultaneously.
+
+status: ready

--- a/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/review-results.md
+++ b/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/review-results.md
@@ -1,0 +1,92 @@
+# Review Results — Issue 52: Chunks Not Calculated Properly on X Content
+
+## Files Reviewed
+
+- `src/types/article.ts`
+- `src/utils/xContentGenerator.ts`
+- `src/components/platforms/PlatformX.vue`
+- `src/utils/xContentGenerator.test.ts`
+
+---
+
+## Tool Output
+
+### `npm run lint`
+
+```
+> vue-boilerplate-jli@0.0.0 lint
+> eslint . --fix
+
+Oops! Something went wrong! :(
+
+ESLint: 9.39.3
+
+SyntaxError: Unexpected token ':'
+    at compileSourceTextModule (node:internal/modules/esm/utils:318:16)
+    ...
+```
+
+**Note:** This error is pre-existing and caused by a structural bug in `eslint.config.js` (a bare `rules:` object is placed as a top-level array element instead of inside a config entry object). This bug predates issue 52 and is not introduced by the changes under review. ESLint could not run against the changed files.
+
+### `npm run type-check`
+
+```
+> vue-boilerplate-jli@0.0.0 type-check
+> vue-tsc --build
+```
+
+No errors. Type-check passes cleanly.
+
+---
+
+## Security Checklist
+
+All six security rules from `security-guidelines.md` are addressed:
+
+- **Rule 1 (textContent only):** `extractParagraphTexts` in `xContentGenerator.ts` reads `node.textContent` exclusively — `innerHTML` is never accessed.
+- **Rule 2 (no v-html):** `PlatformX.vue` uses `{{ chunk.text }}` interpolation inside `<pre>`, not `v-html`.
+- **Rule 3 (static warning string):** The warning message in `PlatformX.vue` (line 67-69) is a hardcoded string literal in the template — not derived from any data property, computed value, or article content.
+- **Rule 4 (warning excluded from clipboard):** `CopyButton` receives `:text="chunk.text"` only; the warning `<p>` is a separate sibling element and its content is never concatenated into the copy payload.
+- **Rule 5 (oversized flag from length only):** In `buildRawChunksFromParagraph`, `oversized: true` is set solely by comparing `paragraphText.length` against `MAX_CHUNK_LENGTH` — no value from article HTML influences the flag.
+- **Rule 6 (no new runtime dependencies):** Only `DOMParser` (browser-native) and existing project utilities are used. No new npm packages were added.
+
+---
+
+## Business Spec Checklist
+
+- **Rule 1 (paragraph-first chunking):** Each `<p>` element is processed independently by `buildRawChunksFromParagraph`; paragraphs are never merged into a shared chunk.
+- **Rule 2 (sentence boundary splitting):** `splitIntoSentences` and `buildChunksFromSentences` implement sentence accumulation splitting at `. `, `! `, and `? `.
+- **Rule 3 (oversized flag):** Set in `buildRawChunksFromParagraph` when paragraph length exceeds 280 and no sentence boundary exists.
+- **Rule 4 (orange border + warning message):** `:class="{ 'border-orange-500': chunk.oversized }"` and `v-if="chunk.oversized"` warning `<p>` are present in `PlatformX.vue`.
+- **Rule 5 (unchanged formatting for non-oversized chunks):** `formatChunks` appends `\n\n⬇️` to non-last chunks and `\n\n⬇️⬇️⬇️\n{utmLink}` to the last chunk; `oversized` flag is preserved through formatting unchanged.
+- **Rule 6 (chunk count label):** `chunkCountLabel` computed in `PlatformX.vue` appends `, {n} oversized` when `oversizedCount > 0`; shows only the total when no oversized chunks exist.
+
+---
+
+## Test File Checklist
+
+- **`chunk.text` used in all string assertions:** All previously failing string-method calls (`endsWith`, `includes`, `replace`, `toContain`, `toBe`) now correctly reference `chunk.text`, `lastChunk.text`, `result.chunks[0].text`, etc. No direct method calls on `XChunk` objects remain.
+- **Paragraph-first chunking tests:** `describe('paragraph-first chunking', ...)` block (line 224) covers two-paragraph splitting and each paragraph remaining independent.
+- **Oversized flag assignment:** Test at line 259 asserts `result.chunks[0].oversized` is `true` for a paragraph exceeding 280 chars with no sentence boundary.
+- **Warning text exclusion from chunk text:** Test at line 271 asserts no chunk's `.text` field contains the warning message keywords (`'oversized'`, `'warning'`, `'exceeds'`).
+- **No sentence-boundary paragraphs without oversized flag:** Test at line 238 asserts all chunks from a long paragraph that has sentence boundaries carry a falsy `oversized` value.
+
+---
+
+## Object Calisthenics Checklist
+
+- No `else` keyword in `xContentGenerator.ts` or `PlatformX.vue`.
+- Each function in `xContentGenerator.ts` has a clear single responsibility. The `buildChunksFromSentences` function is the longest at ~26 lines but contains no internal branching complexity beyond a single `for` loop — consistent with the existing codebase style.
+- No abbreviations in exported or module-level names.
+- No dead code or unused imports in any changed file.
+- Naming is clear throughout: `extractParagraphTexts`, `hasSentenceBoundary`, `buildRawChunksFromParagraph`, `buildChunksFromSentences`, `formatChunks`, `oversizedCount`, `chunkCountLabel`.
+
+---
+
+## Summary
+
+All findings from the previous review have been resolved. The test file now uses `chunk.text` (and equivalent `.text` accesses) in every string assertion. The four new test cases covering paragraph-first chunking, sentence-boundary splitting without oversized flag, oversized flag assignment, and warning text exclusion from chunk text are present and correctly structured. The type-check passes with no errors.
+
+The pre-existing ESLint config bug (`eslint.config.js`) is the only known issue and predates this change.
+
+status: approved

--- a/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/security-guidelines.md
+++ b/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/security-guidelines.md
@@ -1,0 +1,65 @@
+# Security Guidelines — Issue 52: Chunks Not Calculated Properly on X Content
+
+## Rules
+
+### Rule 1 — Extract paragraph text using `textContent`, never `innerHTML`
+
+**What:** When iterating over `<p>` elements parsed from the article introduction HTML, read each paragraph's plain text via the DOM `textContent` property only. Do not read or forward `innerHTML` from those elements into any chunk string.
+
+**Where:** The utility function that replaces the current `htmlToText` call in `xContentGenerator.ts` — specifically wherever `<p>` nodes are queried and their content read.
+
+**Why:** The introduction HTML originates from a remote server response fetched through the Netlify CORS proxy. Although the domain whitelist restricts which origins are accepted, the fetched content is still untrusted third-party HTML. Reading raw `innerHTML` from parsed nodes and placing it into chunk strings creates a path for injected HTML or script fragments to propagate into reactive state. Using `textContent` ensures only the decoded character data is extracted, stripping all markup at the point of extraction.
+
+---
+
+### Rule 2 — Do not bind chunk strings to `v-html`
+
+**What:** Chunk strings (the copyable text placed in `XContent.chunks`) must never be bound to Vue's `v-html` directive in `PlatformX.vue` or any other template that renders chunk content.
+
+**Where:** `PlatformX.vue` template, and any future component that renders X chunk content.
+
+**Why:** Chunk strings are assembled from `textContent` values and therefore contain plain text, but if the rendering path is ever changed to `v-html`, any HTML that survived earlier processing steps would execute in the browser. The existing `<pre>` + text interpolation (`{{ chunk }}`) pattern is correct and must be preserved. ADR-007 establishes that `v-html` requires DOMPurify sanitization; this rule avoids the risk entirely by keeping the render path HTML-free.
+
+---
+
+### Rule 3 — Render the oversized warning message as a static string literal, not from data
+
+**What:** The warning message text "This chunk exceeds 280 characters and could not be split. Consider adapting it before posting." must be a hardcoded string in the template or component, not a value read from the chunk object, a computed property derived from external input, or a server-supplied string.
+
+**Where:** `PlatformX.vue` template, in the conditional block that displays the warning for oversized chunks.
+
+**Why:** The warning is a fixed informational message defined by the business specification. Deriving it from data — even from a field on the chunk object — introduces a code path where an unexpected value (originating from malformed article HTML) could reach the rendered UI. A static literal has no such attack surface.
+
+---
+
+### Rule 4 — Exclude the warning message from all clipboard write operations
+
+**What:** The string passed to the copy action for a chunk must contain only the chunk's copyable text (content plus arrow/UTM suffix). The warning message string must never be concatenated into, or otherwise included in, the value written to the clipboard.
+
+**Where:** The copy handler in `PlatformX.vue` (currently using `CopyButton` with a `:text` binding).
+
+**Why:** If warning text were included in the clipboard payload, a user pasting into a social platform would publish the warning as part of the post. Beyond the user-facing impact, this also ensures the clipboard write path is driven solely by the structured chunk data and not by any UI-layer string that could be influenced by unexpected content in the article.
+
+---
+
+### Rule 5 — The `oversized` flag must be a boolean derived only from chunk length, not from article content
+
+**What:** The oversized marker on a chunk object must be set exclusively by comparing the raw plain-text length of the chunk against the 280-character limit. It must not be read from, inferred from, or influenced by any value present in the source HTML.
+
+**Where:** The chunking logic in `xContentGenerator.ts` (or the utility it delegates to).
+
+**Why:** If the flag were derived from a field in the article HTML (e.g., a class name or attribute), a malicious or malformed page could artificially set or suppress the flag. Keeping the flag as a pure boolean computed from string length closes this vector and keeps the security-relevant branching logic deterministic and testable.
+
+---
+
+### Rule 6 — No new external runtime dependencies may be introduced
+
+**What:** The implementation must use only browser-native APIs (`DOMParser`, DOM node properties) and existing project utilities. No new npm packages may be added to handle HTML parsing, text extraction, or chunk structuring.
+
+**Where:** `xContentGenerator.ts`, `htmlToText.ts`, and any new utility files created for this issue.
+
+**Why:** Each new dependency expands the supply-chain attack surface. The browser's native `DOMParser` already provides a sandboxed parsing environment sufficient for extracting `textContent` from `<p>` elements. Adding a third-party HTML parser for this purpose would introduce unreviewed code into the trusted execution path without a corresponding security gain.
+
+---
+
+status: ready

--- a/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/technical-specifications.md
+++ b/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/technical-specifications.md
@@ -1,0 +1,65 @@
+# Technical Specifications — Issue 52: Chunks Not Calculated Properly on X Content
+
+## Files Changed
+
+### `src/types/article.ts`
+Added new `XChunk` interface with `text: string` and `oversized?: boolean` fields. Changed `XContent.chunks` from `string[]` to `XChunk[]`.
+
+### `src/utils/xContentGenerator.ts`
+Replaced the single-string `htmlToText` flow with a paragraph-first chunking pipeline. Added `extractParagraphTexts`, `hasSentenceBoundary`, and `buildRawChunksFromParagraph` functions. Updated `formatChunks` to accept and return `XChunk`-shaped objects. Updated `generateXContent` to drive the new pipeline.
+
+### `src/components/platforms/PlatformX.vue`
+Updated chunk rendering to use `chunk.text` for display and copy. Added `border-orange-500` conditional class when `chunk.oversized` is true. Added static warning message paragraph rendered only when `chunk.oversized` is true. Updated `chunkCountLabel` computed to include oversized count when greater than zero. Added `oversizedCount` computed property.
+
+### `src/utils/xContentGenerator.test.ts`
+Updated all chunk access from direct string methods to `.text` property to match the `XChunk` type; added four new tests covering paragraph-first chunking, sentence-boundary splitting, oversized flag assignment, and warning message exclusion from chunk text.
+
+---
+
+## Non-Trivial Decisions
+
+### Why `extractParagraphTexts` uses `querySelectorAll('p')` rather than iterating `childNodes`
+
+The article introduction HTML stored in `Article.introduction` is a fragment of paragraph elements. Using `querySelectorAll('p')` on the parsed document body selects all `<p>` nodes regardless of nesting depth, which matches how the existing `htmlExtractor.ts` collects introduction paragraphs (all `<p>` tags before the first `<h2>` in `.article-content`). A `childNodes` walk would miss `<p>` elements wrapped in a container div that some blog templates produce.
+
+### Why the `oversized` flag is omitted (not set to `false`) when not needed
+
+The `XChunk` interface declares `oversized?: boolean` (optional). Chunks that are not oversized omit the field entirely rather than explicitly setting `false`. This keeps the objects lean and makes truthiness checks (`if (chunk.oversized)`) naturally falsy for absent fields, consistent with Vue template `v-if` behaviour.
+
+### Why `buildRawChunksFromParagraph` is a separate function from `buildChunksFromSentences`
+
+The paragraph-level decision (fits ≤280, has no boundary → oversized, has boundary → sentence-split) is distinct from the sentence-accumulation logic. Separating them keeps each function at ≤5 lines of meaningful logic, satisfies the Object Calisthenics single-responsibility rule, and makes the oversized path independently testable without involving sentence splitting.
+
+### Why `formatChunks` now takes a generic intermediate type instead of `string[]`
+
+Raw chunk objects carry the `oversized` flag before formatting. If formatting received plain strings, the flag information would be lost and would need to be re-derived after the fact. Passing the intermediate `{ text, oversized? }` shape through `formatChunks` means the flag is propagated to the final `XChunk[]` in one pass with no re-computation.
+
+### Why the warning message in `PlatformX.vue` is a `<p>` not a `<span>` or `<div>`
+
+The message is a standalone informational sentence that follows the chunk content. A `<p>` element is semantically appropriate for a sentence of prose and is consistent with the `<pre>` element above it in the card. Using `<div>` would carry no semantic meaning; using `<span>` would imply inline context within another flow.
+
+---
+
+## Self-Code-Review: Potential Bugs and Performance Issues
+
+### 1. `querySelectorAll('p')` selects nested paragraphs if the HTML ever contains `<div><p>…</p></div>`
+
+**Risk:** If the introduction HTML contains `<p>` elements nested inside block containers (e.g., a `<blockquote><p>…</p></blockquote>`), those paragraphs are returned alongside top-level ones. This could produce duplicate content if the outer container is also iterated.
+
+**How addressed:** The current `htmlExtractor.ts` collects introduction HTML as a sequence of sibling `<p>` elements selected directly from `.article-content` before the first `<h2>`. The resulting HTML fragment is a flat list of `<p>` elements with no block wrappers. The risk is therefore theoretical given the current data shape, but is worth noting if the extraction logic ever changes.
+
+### 2. Whitespace normalisation inside `extractParagraphTexts` collapses intentional line breaks
+
+**Risk:** `(node.textContent ?? '').replace(/\s+/g, ' ').trim()` collapses all whitespace sequences (including newlines) to a single space. A paragraph that deliberately uses `<br>` elements for line structure would lose that structure.
+
+**How addressed:** The X platform post format is plain text. `<br>` line breaks inside a tweet paragraph are not a supported design pattern in the current spec. The normalisation matches the behaviour of the previous `htmlToText` utility and is correct for the current use case. If multi-line paragraphs are required in future, `extractParagraphTexts` is the single function to update.
+
+### 3. `buildChunksFromSentences` may produce a chunk whose raw text exceeds 280 characters when a single sentence is longer than 280 characters
+
+**Risk:** When `splitIntoSentences` returns a sentence longer than `MAX_CHUNK_LENGTH`, `buildChunksFromSentences` assigns it to `current` and eventually pushes it as a chunk. The resulting chunk text is longer than 280 characters but carries no `oversized` flag, because `buildRawChunksFromParagraph` only applies the flag when the entire paragraph has no sentence boundary.
+
+**How addressed:** This is intentional and consistent with Rule 2 of the business specifications: a paragraph that *does* have sentence boundaries is split at those boundaries. If one of the resulting sub-sentences is individually >280 characters, that is a content authoring concern beyond the scope of this fix. The oversized flag is reserved specifically for Rule 3 (no sentence boundary at all). Adding an additional oversized check per sub-sentence would be a separate business rule not covered by issue 52.
+
+---
+
+status: ready

--- a/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/test-results.md
+++ b/docs/prompts/tasks/issue-52-chunks-not-calculated-properly-on-x-content/test-results.md
@@ -1,0 +1,51 @@
+# Test Results — Issue 52: Chunks Not Calculated Properly on X Content
+
+## Run command
+
+```
+npm run test
+```
+
+## Summary counts
+
+- Test files: 17 total — 17 passed, 0 failed
+- Tests: 274 total — 274 passed, 0 failed
+- Duration: 7.65 s
+
+---
+
+## Test file results
+
+| File | Tests | Result |
+|---|---|---|
+| `src/utils/xContentGenerator.test.ts` | 22 | passed |
+| `src/composables/useArticleExtractor.test.ts` | 10 | passed |
+| `src/utils/htmlExtractor.test.ts` | 38 | passed |
+| `src/components/platforms/PlatformMedium.test.ts` | 16 | passed |
+| `src/components/platforms/PlatformSubstack.test.ts` | 13 | passed |
+| `src/components/platforms/PlatformSwitcher.test.ts` | 18 | passed |
+| `src/components/layout/GuestLayout.test.ts` | 9 | passed |
+| `src/components/article/ArticleInput.test.ts` | 16 | passed |
+| `src/components/article/ManualIntroduction.test.ts` | 13 | passed |
+| `src/components/platforms/PlatformLinkedIn.test.ts` | 6 | passed |
+| `src/components/layout/AppFooter.test.ts` | 10 | passed |
+| `src/utils/linkedInContentGenerator.test.ts` | 17 | passed |
+| `src/utils/htmlToText.test.ts` | 15 | passed |
+| `src/utils/mediumContentGenerator.test.ts` | 20 | passed |
+| `src/utils/substackContentGenerator.test.ts` | 20 | passed |
+| `src/utils/utm.test.ts` | 22 | passed |
+| `src/composables/useArticleState.test.ts` | 9 | passed |
+
+---
+
+## Notes
+
+`src/components/article/ArticleInput.test.ts` emits Vue router injection warnings (`[Vue warn]: injection "Symbol(router)" not found`) to stderr for all 16 of its tests. These are non-fatal test environment warnings; all tests pass despite them.
+
+---
+
+### Test Summary
+
+All 274 tests across 17 test files passed. The previously failing test in `src/utils/xContentGenerator.test.ts` ("warning message does not appear in any chunk text field") now passes — the test fixture string no longer contains the substrings being asserted against, confirming the fix for the oversized-chunk word containment check is correct.
+
+status: passed

--- a/src/components/platforms/PlatformX.vue
+++ b/src/components/platforms/PlatformX.vue
@@ -20,9 +20,18 @@ const chunks = computed(() => {
   return generateXContent(article.value).chunks
 })
 
+const oversizedCount = computed(() => chunks.value.filter((chunk) => chunk.oversized).length)
+
 const chunkCountLabel = computed(() => {
-  const count = chunks.value.length
-  return count === 1 ? '1 chunk to post' : `${count} chunks to post`
+  const total = chunks.value.length
+  const oversized = oversizedCount.value
+  const baseLabel = total === 1 ? '1 chunk to post' : `${total} chunks to post`
+
+  if (oversized === 0) {
+    return baseLabel
+  }
+
+  return `${baseLabel}, ${oversized} oversized`
 })
 
 function startOver(): void {
@@ -51,9 +60,13 @@ function startOver(): void {
           v-for="(chunk, index) in chunks"
           :key="index"
           class="chunk border rounded-lg p-4"
+          :class="{ 'border-orange-500': chunk.oversized }"
         >
-          <pre class="whitespace-pre-wrap text-sm mb-3">{{ chunk }}</pre>
-          <CopyButton :text="chunk" label="Copy chunk" />
+          <pre class="whitespace-pre-wrap text-sm mb-3">{{ chunk.text }}</pre>
+          <CopyButton :text="chunk.text" label="Copy chunk" />
+          <p v-if="chunk.oversized" class="text-sm text-orange-600 mt-2">
+            This chunk exceeds 280 characters and could not be split. Consider adapting it before posting.
+          </p>
         </div>
       </div>
 

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -72,12 +72,25 @@ export interface ExtractionState {
 }
 
 /**
+ * A single X (Twitter) chunk with optional oversized warning flag.
+ * The `text` field holds the fully formatted chunk (with arrow/UTM suffix).
+ * The `oversized` flag is true when the source paragraph exceeds 280 characters
+ * and contains no sentence boundary that would allow splitting.
+ */
+export interface XChunk {
+  /** Fully formatted chunk text including arrow/UTM suffix */
+  text: string
+  /** True when paragraph exceeded 280 chars with no sentence boundary */
+  oversized?: boolean
+}
+
+/**
  * Generated content for X (Twitter)
  * Introduction split into 280-character chunks
  */
 export interface XContent {
-  /** Array of text chunks, each ≤280 chars, individually copyable */
-  chunks: string[]
+  /** Array of chunk objects, each with formatted text and optional oversized flag */
+  chunks: XChunk[]
 }
 
 /**

--- a/src/utils/xContentGenerator.test.ts
+++ b/src/utils/xContentGenerator.test.ts
@@ -270,7 +270,7 @@ describe('generateXContent', () => {
 
     it('warning message does not appear in any chunk text field', () => {
       const longSentence =
-        'This is a very long sentence with absolutely no terminal punctuation followed by a space so the algorithm cannot split it and it must be placed as a single oversized chunk regardless of the two-hundred-and-eighty character limit that normally applies to tweets posted on the X platform'
+        'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum'
       const article = makeArticle({ introduction: `<p>${longSentence}</p>` })
       const result = generateXContent(article)
 

--- a/src/utils/xContentGenerator.test.ts
+++ b/src/utils/xContentGenerator.test.ts
@@ -53,7 +53,7 @@ describe('generateXContent', () => {
       const article = makeArticle({ url, introduction: `<p>${intro}</p>` })
       const utmLink = generateUTMLink(url, 'X')
       const result = generateXContent(article)
-      expect(result.chunks[0]).toBe(`${intro}\n\n⬇️⬇️⬇️\n${utmLink}`)
+      expect(result.chunks[0].text).toBe(`${intro}\n\n⬇️⬇️⬇️\n${utmLink}`)
     })
 
     it('chunk content is ≤280 chars before the appended separator+link', () => {
@@ -97,7 +97,7 @@ describe('generateXContent', () => {
       const result = generateXContent(article)
       const allButLast = result.chunks.slice(0, -1)
       allButLast.forEach((chunk, i) => {
-        expect(chunk.endsWith('\n\n⬇️'), `chunk ${i} should end with ⬇️`).toBe(true)
+        expect(chunk.text.endsWith('\n\n⬇️'), `chunk ${i} should end with ⬇️`).toBe(true)
       })
     })
 
@@ -107,7 +107,7 @@ describe('generateXContent', () => {
       const utmLink = generateUTMLink(url, 'X')
       const result = generateXContent(article)
       const lastChunk = result.chunks[result.chunks.length - 1]
-      expect(lastChunk.endsWith(`\n\n⬇️⬇️⬇️\n${utmLink}`)).toBe(true)
+      expect(lastChunk.text.endsWith(`\n\n⬇️⬇️⬇️\n${utmLink}`)).toBe(true)
     })
 
     it('non-last chunks do NOT end with ⬇️⬇️⬇️', () => {
@@ -115,7 +115,7 @@ describe('generateXContent', () => {
       const result = generateXContent(article)
       const allButLast = result.chunks.slice(0, -1)
       allButLast.forEach((chunk, i) => {
-        expect(chunk.includes('⬇️⬇️⬇️'), `chunk ${i} must not contain triple arrows`).toBe(false)
+        expect(chunk.text.includes('⬇️⬇️⬇️'), `chunk ${i} must not contain triple arrows`).toBe(false)
       })
     })
 
@@ -124,7 +124,7 @@ describe('generateXContent', () => {
       const result = generateXContent(article)
       result.chunks.forEach((chunk, i) => {
         // Strip the formatting suffix to get the raw chunk text
-        const rawChunk = chunk
+        const rawChunk = chunk.text
           .replace(/\n\n⬇️⬇️⬇️\n.+$/, '') // last chunk suffix
           .replace(/\n\n⬇️$/, '') // non-last chunk suffix
         expect(
@@ -150,7 +150,7 @@ describe('generateXContent', () => {
       const result = generateXContent(article)
       // Should still produce exactly one chunk (the oversized sentence)
       expect(result.chunks).toHaveLength(1)
-      const rawChunk = result.chunks[0].replace(/\n\n⬇️⬇️⬇️\n.+$/, '')
+      const rawChunk = result.chunks[0].text.replace(/\n\n⬇️⬇️⬇️\n.+$/, '')
       expect(rawChunk).toBe(longSentence)
     })
 
@@ -172,7 +172,7 @@ describe('generateXContent', () => {
       expect(result.chunks.length).toBeGreaterThanOrEqual(2)
 
       // First raw chunk must be the long sentence alone
-      const firstRaw = result.chunks[0].replace(/\n\n⬇️$/, '').replace(/\n\n⬇️⬇️⬇️\n.+$/, '')
+      const firstRaw = result.chunks[0].text.replace(/\n\n⬇️$/, '').replace(/\n\n⬇️⬇️⬇️\n.+$/, '')
       expect(firstRaw).toBe(longSentenceWithPeriod)
     })
   })
@@ -186,7 +186,7 @@ describe('generateXContent', () => {
       const result = generateXContent(article)
 
       expect(result.chunks).toHaveLength(1)
-      expect(result.chunks[0]).toBe(`Hello world. This is a test.\n\n⬇️⬇️⬇️\n${utmLink}`)
+      expect(result.chunks[0].text).toBe(`Hello world. This is a test.\n\n⬇️⬇️⬇️\n${utmLink}`)
     })
 
     it('no HTML angle-bracket characters appear in any chunk', () => {
@@ -195,8 +195,8 @@ describe('generateXContent', () => {
       const article = makeArticle({ introduction: html })
       const result = generateXContent(article)
       result.chunks.forEach((chunk) => {
-        expect(chunk).not.toContain('<')
-        expect(chunk).not.toContain('>')
+        expect(chunk.text).not.toContain('<')
+        expect(chunk.text).not.toContain('>')
       })
     })
   })
@@ -208,7 +208,7 @@ describe('generateXContent', () => {
       const expectedLink = generateUTMLink(url, 'X')
       const result = generateXContent(article)
       const lastChunk = result.chunks[result.chunks.length - 1]
-      expect(lastChunk).toContain(expectedLink)
+      expect(lastChunk.text).toContain(expectedLink)
     })
 
     it('UTM link contains utm_medium=social and utm_source=X', () => {
@@ -216,8 +216,71 @@ describe('generateXContent', () => {
       const article = makeArticle({ url, introduction: '<p>A sentence.</p>' })
       const result = generateXContent(article)
       const lastChunk = result.chunks[result.chunks.length - 1]
-      expect(lastChunk).toContain('utm_medium=social')
-      expect(lastChunk).toContain('utm_source=X')
+      expect(lastChunk.text).toContain('utm_medium=social')
+      expect(lastChunk.text).toContain('utm_source=X')
+    })
+  })
+
+  describe('paragraph-first chunking', () => {
+    it('two <p> paragraphs each ≤280 chars produce one chunk per paragraph', () => {
+      const para1 = 'First paragraph, short enough to fit in a single chunk easily.'
+      const para2 = 'Second paragraph, also short enough to remain a single chunk on its own.'
+      const html = `<p>${para1}</p><p>${para2}</p>`
+      const article = makeArticle({ introduction: html })
+      const result = generateXContent(article)
+      expect(result.chunks).toHaveLength(2)
+      const rawFirst = result.chunks[0].text.replace(/\n\n⬇️$/, '').replace(/\n\n⬇️⬇️⬇️\n.+$/, '')
+      const rawSecond = result.chunks[1].text.replace(/\n\n⬇️⬇️⬇️\n.+$/, '')
+      expect(rawFirst).toBe(para1)
+      expect(rawSecond).toBe(para2)
+    })
+
+    it('one <p> >280 chars with sentence boundaries splits across multiple chunks, no oversized flag', () => {
+      const sentence1 =
+        'The first sentence of this article is intentionally written to be quite long and descriptive.'
+      const sentence2 =
+        'The second sentence continues the thought and adds even more context for the reader.'
+      const sentence3 =
+        'The third sentence wraps up the opening paragraph with a concluding remark about the topic.'
+      const sentence4 =
+        'A fourth sentence is added to make absolutely certain that the text exceeds the 280-character limit.'
+      const introText = `${sentence1} ${sentence2} ${sentence3} ${sentence4}`
+      expect(introText.length).toBeGreaterThan(280)
+
+      const article = makeArticle({ introduction: `<p>${introText}</p>` })
+      const result = generateXContent(article)
+
+      expect(result.chunks.length).toBeGreaterThan(1)
+      result.chunks.forEach((chunk) => {
+        expect(chunk.oversized).toBeFalsy()
+      })
+    })
+
+    it('one <p> >280 chars with no sentence boundary produces one chunk with oversized: true', () => {
+      const longSentence =
+        'This is a very long sentence with absolutely no terminal punctuation followed by a space so the algorithm cannot split it and it must be placed as a single oversized chunk regardless of the two-hundred-and-eighty character limit that normally applies to tweets posted on the X platform'
+      expect(longSentence.length).toBeGreaterThan(280)
+
+      const article = makeArticle({ introduction: `<p>${longSentence}</p>` })
+      const result = generateXContent(article)
+
+      expect(result.chunks).toHaveLength(1)
+      expect(result.chunks[0].oversized).toBe(true)
+    })
+
+    it('warning message does not appear in any chunk text field', () => {
+      const longSentence =
+        'This is a very long sentence with absolutely no terminal punctuation followed by a space so the algorithm cannot split it and it must be placed as a single oversized chunk regardless of the two-hundred-and-eighty character limit that normally applies to tweets posted on the X platform'
+      const article = makeArticle({ introduction: `<p>${longSentence}</p>` })
+      const result = generateXContent(article)
+
+      result.chunks.forEach((chunk) => {
+        // The warning message is rendered by PlatformX.vue separately; it must
+        // never appear inside the chunk text that goes to the clipboard.
+        expect(chunk.text).not.toContain('oversized')
+        expect(chunk.text).not.toContain('warning')
+        expect(chunk.text).not.toContain('exceeds')
+      })
     })
   })
 })

--- a/src/utils/xContentGenerator.ts
+++ b/src/utils/xContentGenerator.ts
@@ -3,21 +3,45 @@
  *
  * Splits an article introduction into tweet-sized chunks (≤280 chars each),
  * with visual separators and a UTM-tagged link on the last chunk.
+ *
+ * Chunking is paragraph-first: each HTML <p> element is treated as an
+ * independent unit. Content from different paragraphs is never merged.
  */
 
-import type { Article, XContent } from '@/types/article'
-import { htmlToText } from './htmlToText'
+import type { Article, XChunk, XContent } from '@/types/article'
 import { generateUTMLink } from './utm'
 
 const MAX_CHUNK_LENGTH = 280
 
 /**
+ * Extract plain text from each <p> element in an HTML string.
+ * Uses DOMParser and reads textContent (never innerHTML) to prevent
+ * any HTML from reaching the chunk strings.
+ *
+ * @param html - Raw HTML string containing <p> elements
+ * @returns Array of trimmed non-empty paragraph plain-text strings
+ */
+function extractParagraphTexts(html: string): string[] {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+  const paragraphNodes = doc.querySelectorAll('p')
+  const texts: string[] = []
+
+  for (const node of paragraphNodes) {
+    const text = (node.textContent ?? '').replace(/\s+/g, ' ').trim()
+    if (text.length > 0) {
+      texts.push(text)
+    }
+  }
+
+  return texts
+}
+
+/**
  * Split plain text into sentences, keeping trailing punctuation attached.
+ * Splits on `. `, `! `, `? ` boundaries.
  *
- * Splits on `. `, `! `, `? ` boundaries so the punctuation stays with
- * the sentence that produced it.
- *
- * @param text - Collapsed plain text
+ * @param text - Plain text to split
  * @returns Array of sentence strings
  */
 function splitIntoSentences(text: string): string[] {
@@ -45,13 +69,14 @@ function splitIntoSentences(text: string): string[] {
 }
 
 /**
- * Accumulate sentences into chunks where each chunk does not exceed MAX_CHUNK_LENGTH.
- * A sentence longer than MAX_CHUNK_LENGTH becomes its own chunk regardless.
+ * Accumulate sentences from one paragraph into raw chunks where each chunk
+ * does not exceed MAX_CHUNK_LENGTH. A sentence longer than MAX_CHUNK_LENGTH
+ * becomes its own chunk regardless.
  *
- * @param sentences - Array of sentence strings
- * @returns Array of chunk strings (without formatting)
+ * @param sentences - Array of sentence strings from a single paragraph
+ * @returns Array of raw chunk strings (without formatting suffixes)
  */
-function buildChunks(sentences: string[]): string[] {
+function buildChunksFromSentences(sentences: string[]): string[] {
   const chunks: string[] = []
   let current = ''
 
@@ -80,23 +105,59 @@ function buildChunks(sentences: string[]): string[] {
 }
 
 /**
- * Apply visual formatting to chunks:
- * - Every chunk except the last gets `\n\n⬇️` appended.
- * - The last chunk gets `\n\n⬇️⬇️⬇️\n{utmLink}` appended.
+ * Check whether a paragraph text has any sentence boundary (`. `, `! `, `? `).
  *
- * @param chunks - Raw unformatted chunks
- * @param utmLink - UTM-tagged article URL
- * @returns Formatted chunk strings ready for display/copy
+ * @param text - Plain-text paragraph
+ * @returns True when at least one sentence boundary exists
  */
-function formatChunks(chunks: string[], utmLink: string): string[] {
-  return chunks.map((chunk, index) => {
-    const isLast = index === chunks.length - 1
+function hasSentenceBoundary(text: string): boolean {
+  return text.includes('. ') || text.includes('! ') || text.includes('? ')
+}
 
-    if (isLast) {
-      return chunk + '\n\n⬇️⬇️⬇️\n' + utmLink
+/**
+ * Convert a single paragraph text into raw chunk objects.
+ * Short paragraphs (≤280 chars) become one chunk.
+ * Long paragraphs are split at sentence boundaries when possible;
+ * if no boundary exists the whole paragraph becomes one oversized chunk.
+ *
+ * @param paragraphText - Trimmed plain-text content of one <p> element
+ * @returns Array of raw chunk objects (text without formatting suffix, oversized flag)
+ */
+function buildRawChunksFromParagraph(paragraphText: string): Array<{ text: string; oversized?: boolean }> {
+  if (paragraphText.length <= MAX_CHUNK_LENGTH) {
+    return [{ text: paragraphText }]
+  }
+
+  if (!hasSentenceBoundary(paragraphText)) {
+    return [{ text: paragraphText, oversized: true }]
+  }
+
+  const sentences = splitIntoSentences(paragraphText)
+  const chunkTexts = buildChunksFromSentences(sentences)
+  return chunkTexts.map((text) => ({ text }))
+}
+
+/**
+ * Apply visual formatting to raw chunk objects:
+ * - Every chunk except the last gets `\n\n⬇️` appended to its text.
+ * - The last chunk gets `\n\n⬇️⬇️⬇️\n{utmLink}` appended to its text.
+ * The `oversized` flag is preserved unchanged.
+ *
+ * @param rawChunks - Unformatted chunk objects
+ * @param utmLink - UTM-tagged article URL
+ * @returns Formatted XChunk objects ready for display/copy
+ */
+function formatChunks(rawChunks: Array<{ text: string; oversized?: boolean }>, utmLink: string): XChunk[] {
+  return rawChunks.map((chunk, index) => {
+    const isLast = index === rawChunks.length - 1
+    const suffix = isLast ? '\n\n⬇️⬇️⬇️\n' + utmLink : '\n\n⬇️'
+    const formattedText = chunk.text + suffix
+
+    if (chunk.oversized) {
+      return { text: formattedText, oversized: true }
     }
 
-    return chunk + '\n\n⬇️'
+    return { text: formattedText }
   })
 }
 
@@ -104,17 +165,22 @@ function formatChunks(chunks: string[], utmLink: string): string[] {
  * Generate X (Twitter) content from an article.
  *
  * @param article - Extracted article data
- * @returns XContent with an array of formatted tweet chunks
+ * @returns XContent with an array of formatted XChunk objects
  */
 export function generateXContent(article: Article): XContent {
-  const plainText = htmlToText(article.introduction)
+  const paragraphTexts = extractParagraphTexts(article.introduction)
 
-  if (plainText === '') {
+  if (paragraphTexts.length === 0) {
     return { chunks: [] }
   }
 
-  const sentences = splitIntoSentences(plainText)
-  const rawChunks = buildChunks(sentences)
+  const rawChunks: Array<{ text: string; oversized?: boolean }> = []
+
+  for (const paragraphText of paragraphTexts) {
+    const paragraphChunks = buildRawChunksFromParagraph(paragraphText)
+    rawChunks.push(...paragraphChunks)
+  }
+
   const utmLink = generateUTMLink(article.url, 'X')
   const chunks = formatChunks(rawChunks, utmLink)
 


### PR DESCRIPTION
## Summary

- One `<p>` paragraph now maps to one or more X chunks instead of all paragraphs collapsing into a single string
- Long paragraphs (>280 chars) split at sentence boundaries (`. ` / `! ` / `? `)
- Paragraphs >280 chars with no sentence boundary get an `oversized: true` flag shown as an orange border + warning message in the UI (warning not copied)
- Chunk count label now reads "N chunks to post, M oversized" when applicable

## Test plan

- [x] 274 unit tests pass (22 in `xContentGenerator.test.ts` including 4 new paragraph-first chunking tests)
- [x] Type-check clean
- [x] New tests cover: two-paragraph independence, sentence-boundary splitting, oversized flag assignment, warning text excluded from `chunk.text`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)