### PR TITLE
ci(agent): upgrade agents to bare-repo worktree workflow

### DIFF
--- a/.agents-brain/agent-0-orchestrator.md
+++ b/.agents-brain/agent-0-orchestrator.md
@@ -21,13 +21,16 @@ Build:
 
 Save the user request to `[task-folder]/README.md`.
 
-Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 1 and Task 2 only** (pull latest develop and create the branch). Do not ask it to commit or push yet.
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 1 and Task 2 only** (fetch latest from origin and create the branch + worktree). Do not ask it to commit or push yet.
 
-Wait for the branch to be created before proceeding.
+Wait for the agent to report back the worktree path (`Worktree: <absolute-path>`). Store this path as `[worktree]` — pass it in the `Worktree:` field of every subsequent subagent task handoff.
 
 ### Step 1 — Specs
 
-Read `.agents-brain/agent-1-specs.md` and spawn a subagent using the Task tool with that prompt. Pass the task folder path `[task-folder]` to the subagent.
+Read `.agents-brain/agent-1-specs.md` and spawn a subagent using the Task tool with that prompt. Pass the following to the subagent:
+
+- `Task folder: [task-folder]`
+- `Worktree: [worktree]`
 
 The subagent will read `[task-folder]/README.md` and write `[task-folder]/business-specifications.md`.
 
@@ -38,11 +41,14 @@ If the spec file contains `### ADR Required`, pause the pipeline and use AskUser
 Use AskUserQuestion to show the user a summary of `[task-folder]/business-specifications.md` and ask for approval before proceeding to commit changes.
 If the user does not approve, stop the pipeline and report why.
 
-Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3 only** (commit specs output). Then proceed to Step 1.5.
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3 only** (commit specs output). Pass `Worktree: [worktree]`. Then proceed to Step 1.5.
 
 ### Step 1.5 — Security
 
-Read `.agents-brain/agent-5-security.md` and spawn a subagent using the Task tool with that prompt. Pass the task folder path `[task-folder]` to the subagent.
+Read `.agents-brain/agent-5-security.md` and spawn a subagent using the Task tool with that prompt. Pass the following to the subagent:
+
+- `Task folder: [task-folder]`
+- `Worktree: [worktree]`
 
 The subagent reads `[task-folder]/business-specifications.md` and writes `[task-folder]/security-guidelines.md`.
 
@@ -50,15 +56,16 @@ Wait for `[task-folder]/security-guidelines.md` to end with `status: ready`.
 
 If the file contains `### ADR Required`, pause the pipeline and use AskUserQuestion to present the ADR details to the user. The human must approve the ADR before coding starts. If the user does not approve, stop the pipeline and report why.
 
-Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3.5 only** (commit security guidelines). Then proceed to coding.
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 3.5 only** (commit security guidelines). Pass `Worktree: [worktree]`. Then proceed to coding.
 
 ### Step 2 — Coding
 
-Read `.agents-brain/agent-2-coder.md` and spawn a subagent using the Task tool with that prompt. Pass the task folder path `[task-folder]` to the subagent.
+Read `.agents-brain/agent-2-coder.md` and spawn a subagent using the Task tool with that prompt. Pass the following to the subagent:
 
-For all tasks, the subagent reads `[task-folder]/business-specifications.md`.
+- `Task folder: [task-folder]`
+- `Worktree: [worktree]`
 
-The subagent writes `[task-folder]/technical-specifications.md`.
+The subagent reads `[task-folder]/business-specifications.md` and writes `[task-folder]/technical-specifications.md`.
 
 Wait for `[task-folder]/technical-specifications.md` to end with either `status: ready` or `status: review specs`.
 
@@ -71,9 +78,12 @@ If `status: ready`, proceed to Step 2.5.
 
 ### Step 2.5 — Code Review
 
-Read `.agents-brain/agent-6-reviewer.md` and spawn a subagent using the Task tool with that prompt. Pass the task folder path `[task-folder]` to the subagent.
+Read `.agents-brain/agent-6-reviewer.md` and spawn a subagent using the Task tool with that prompt. Pass the following to the subagent:
 
-The subagent reviews the changed source files against `[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`, runs `npm run lint` and `npm run type-check`, and writes `[task-folder]/review-results.md`.
+- `Task folder: [task-folder]`
+- `Worktree: [worktree]`
+
+The subagent reviews the changed source files against `[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`, runs `npm run lint` and `npm run type-check` from `[worktree]`, and writes `[task-folder]/review-results.md`.
 
 Wait for `[task-folder]/review-results.md` to end with either `status: approved` or `status: changes requested`.
 
@@ -87,11 +97,14 @@ If `status: approved`:
 - If `[task-folder]/technical-specifications.md` contains `### ADR Required`, pause the pipeline and use AskUserQuestion to present the ADR details to the user. The human must approve the ADR before committing code. If the user does not approve, stop the pipeline.
 - Use AskUserQuestion to show the user a summary of `[task-folder]/technical-specifications.md` and ask for approval before testing.
   - If the user does not approve, stop the pipeline.
-- Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 4 only** (commit code and review changes).
+- Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 4 only** (commit code and review changes). Pass `Worktree: [worktree]`.
 
 ### Step 3 — Testing
 
-Read `.agents-brain/agent-3-tester.md` and spawn a subagent using the Task tool with that prompt. Pass the task folder path `[task-folder]` to the subagent.
+Read `.agents-brain/agent-3-tester.md` and spawn a subagent using the Task tool with that prompt. Pass the following to the subagent:
+
+- `Task folder: [task-folder]`
+- `Worktree: [worktree]`
 
 The subagent writes `[task-folder]/test-results.md`.
 
@@ -109,7 +122,7 @@ If MAX_RETRIES is exceeded at any step, stop the pipeline and report the failure
 
 ### Step 4 — Versioning
 
-Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 5 only** (commit test results and push the branch).
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 5 only** (commit test results and push the branch). Pass `Worktree: [worktree]`.
 
 Report the branch name and commit message to the user when done.
 
@@ -121,7 +134,9 @@ Once approved, create the PR using `gh pr create`.
 
 Use AskUserQuestion a second time to ask the user for approval to merge the PR. If the user does not approve, stop — the PR remains open for the user to merge manually.
 
-Once approved, run the merge command and return local repository to `develop branch`.
+Once approved, run the merge command.
+
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 6 only** (remove the worktree and update develop). Pass `Worktree: [worktree]`.
 
 ## Bug Feedback Loop
 

--- a/.agents-brain/agent-1-specs.md
+++ b/.agents-brain/agent-1-specs.md
@@ -2,6 +2,10 @@
 
 Using the project context in CLAUDE.md and README.md, write a detailed business spec to `business-specifications.md` inside the task folder passed by the orchestrator.
 
+The orchestrator passes:
+- `Task folder: [task-folder]` — directory where all pipeline artifacts are written
+- `Worktree: [worktree]` — absolute path to the active worktree; resolve `[task-folder]` as a path under it
+
 Take the request in `[task-folder]/README.md` to understand the feature or change being requested and write the specifications.
 
 The specifications must include:

--- a/.agents-brain/agent-2-coder.md
+++ b/.agents-brain/agent-2-coder.md
@@ -2,6 +2,8 @@
 
 Read the business spec at `[task-folder]/business-specifications.md` and the security guidelines at `[task-folder]/security-guidelines.md` passed by the orchestrator. Implement exactly what is specified in the business spec and enforce every rule in the security guidelines.
 
+All file paths are relative to the **worktree root** passed by the orchestrator (`Worktree:` field). Do not read or write files outside that directory.
+
 Follow the architecture described in CLAUDE.md. Do not add features beyond the spec.
 
 When implementation is complete:

--- a/.agents-brain/agent-3-tester.md
+++ b/.agents-brain/agent-3-tester.md
@@ -9,7 +9,7 @@ Write and run tests that cover:
 - Edge cases mentioned in the spec
 - Any error/failure conditions
 
-Use `npm run test` (Vitest) to run the test suite. Test files are TypeScript (`.spec.ts`), placed alongside source files or in `src/__tests__/`.
+Use `npm run test` (Vitest) to run the test suite, executed from the **worktree root** passed by the orchestrator (`Worktree:` field). The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Test files are TypeScript (`.spec.ts`), placed alongside source files or in `src/__tests__/`.
 
 ## Writing the test-results file
 

--- a/.agents-brain/agent-4-git.md
+++ b/.agents-brain/agent-4-git.md
@@ -39,13 +39,21 @@ docs: update API usage in README
 
 ### Task 1: Make Sure Local Repository Is Up-to-date
 
-Pull latest `develop` to ensure the branch is created from a clean base.
+Run `git fetch origin` to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
 
-### Task 2: Create new branch
+### Task 2: Create new branch and worktree
 
 Read the user request file at `[task-folder]/README.md` to understand the nature of the change (feature, fix, or docs).
 
-Create the branch according to `CLAUDE.md` instructions before any other agent writes files.
+Determine `<type>` (e.g. `feat`, `fix`, `ci`, `docs`) and `<slug>` from the issue title.
+
+From inside `<repo>.git/` (the bare repository root), run:
+
+```bash
+git worktree add <type>_<slug> -b <type>/<slug>
+```
+
+The resulting worktree path is `<repo>.git/<type>_<slug>/`. Report this path back to the orchestrator as `Worktree: <absolute-path>` so every subsequent agent can use it.
 
 ### Task 3: Commit specs output
 
@@ -83,6 +91,22 @@ If the last line is `status: passed`:
 - Write a meaningful commit message that summarises the change based on `[task-folder]/business-specifications.md` within Git recommended message length. Put anything beyond the commit message limit into the commit description.
 - Commit on the current feature branch — never commit directly to develop or main.
 - Push the branch to origin.
+- After pushing, update the `develop` worktree so it is ready for the next task:
+
+```bash
+git -C <repo>.git/develop pull
+```
+
+### Task 6: Remove worktree (post-merge cleanup)
+
+Run from inside `<repo>.git/` (the bare repository root):
+
+```bash
+git worktree remove <type>_<slug>
+git branch -d <type>/<slug>
+```
+
+Then run `git -C <repo>.git/develop pull` to ensure `develop` reflects the merged commit.
 
 ## Bug Discovery Rule (applies to all tasks)
 

--- a/.agents-brain/agent-5-security.md
+++ b/.agents-brain/agent-5-security.md
@@ -2,6 +2,10 @@
 
 Read the business spec at `[task-folder]/business-specifications.md` passed by the orchestrator. Produce security guidelines for the coder based on the project's technology stack (Vue 3, TypeScript, Vite, Netlify Functions) and architecture described in CLAUDE.md.
 
+The orchestrator passes:
+- `Task folder: [task-folder]` — directory where all pipeline artifacts are written
+- `Worktree: [worktree]` — absolute path to the active worktree; resolve `[task-folder]` as a path under it
+
 ## Scope of analysis
 
 - Input validation and sanitisation rules relevant to the feature (URL inputs, user-supplied strings, DOM parsing via `DOMParser`)

--- a/.agents-brain/agent-6-reviewer.md
+++ b/.agents-brain/agent-6-reviewer.md
@@ -8,7 +8,7 @@ Read the following files passed by the orchestrator:
 
 Then read every source file listed in the technical spec.
 
-Run `npm run lint` and `npm run type-check` from the repository root. Include their full output in your findings.
+Run `npm run lint` and `npm run type-check` from the **worktree root** passed by the orchestrator (`Worktree:` field). The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their full output in your findings.
 
 Before reviewing Vue/TypeScript-specific issues, fetch the following reference pages to ground your review in current documentation:
 

--- a/CLAUDE-AGENT-WORKFLOW-WORKTREE-AND-AGENT-PARALLELISM.md
+++ b/CLAUDE-AGENT-WORKFLOW-WORKTREE-AND-AGENT-PARALLELISM.md
@@ -1,0 +1,232 @@
+# Claude Agent Brain Update: Parallel Development with Git Worktrees
+
+## Overview
+
+When a repo is cloned with `git clone --bare`, every branch can be checked out as an isolated **worktree** — a real directory on disk with its own working tree but sharing the same `.git` object store. This means multiple Claude instances can work on different branches simultaneously without stepping on each other.
+
+---
+
+## Why Worktrees Over Branches / Stashes
+
+| Concern                  | Classic clone                              | Bare + worktrees                                |
+| ------------------------ | ------------------------------------------ | ----------------------------------------------- |
+| Switching context        | `git stash` / `git checkout` (destructive) | Just open another terminal in another directory |
+| Parallel agents          | Impossible (shared index)                  | Native — each worktree has its own index        |
+| Disk usage               | Full copy per clone                        | One object store, thin working trees            |
+| Merge conflicts at setup | Frequent                                   | Zero — each agent works in isolation            |
+| CI-like discipline       | Hard                                       | Natural — each worktree maps to one branch      |
+
+---
+
+## Recommended Directory Convention
+
+Worktrees live **inside** the bare repo directory, named `<type>_<slug>`:
+
+```plaintext
+<repo>.git/
+  develop/                  ← long-lived worktree for develop
+  feat_new-ui/              ← one Claude instance
+  fix_auth-bug/             ← another Claude instance
+  ci_add-support-worktree/  ← this file lives here
+```
+
+The `<type>` prefix matches the branch type (`feat`, `fix`, `chore`, `ci`, `docs`, …) and is separated from the slug by an underscore. This keeps all worktrees co-located with the bare repo and immediately readable in a directory listing.
+
+Create a worktree for a task (run from anywhere, `GIT_DIR` points at the bare repo):
+
+```bash
+git -C <repo>.git worktree add <type>_<slug> -b <type>/<slug>
+```
+
+Remove it when merged:
+
+```bash
+git -C <repo>.git worktree remove <type>_<slug>
+git -C <repo>.git branch -d <type>/<slug>
+```
+
+---
+
+## Agent Operating Protocol
+
+### 1. One task → one worktree → one terminal
+
+Each Claude instance receives **one well-scoped task** and operates in **its own worktree directory**. It never touches files outside that directory.
+
+```plaintext
+Terminal A  →  <repo>.git/feat_notifications   →  branch: feat/notifications
+Terminal B  →  <repo>.git/fix_post-scheduling  →  branch: fix/post-scheduling
+Terminal C  →  <repo>.git/ci_add-support-worktree → branch: ci/add-support-worktree
+```
+
+### 2. Task handoff format
+
+When spawning a parallel Claude agent, supply:
+
+```plaintext
+Task:       <one-sentence description>
+Worktree:   <repo>.git/<type>_<slug>/
+Branch:     <type>/<slug>
+Base:       develop
+Scope:      <list of files / modules the agent may touch>
+Definition of Done: <acceptance criteria>
+```
+
+### 3. Agent startup checklist
+
+Before touching any code, the agent MUST:
+
+1. `git status` — confirm clean working tree.
+2. `git log --oneline -5` — understand recent history on this branch.
+3. Read any relevant `CLAUDE.md` or project docs in the worktree.
+4. Confirm task scope matches the branch name.
+
+### 4. Agent work loop
+
+```plaintext
+read task → read relevant files → plan → implement → run tests → commit
+```
+
+- Commits go on the local branch only.
+- Do **not** push or open PRs unless explicitly instructed.
+- Do **not** run `git merge`, `git rebase`, or `git reset --hard` without user confirmation.
+
+### 5. Finishing a task
+
+The agent reports back:
+
+```plaintext
+Status:   done | blocked | needs-review
+Branch:   <branch-name>
+Commits:  <short log>
+Notes:    <anything the orchestrator needs to know before merging>
+```
+
+---
+
+## Parallelism Patterns
+
+### Pattern A — Feature Fan-Out
+
+Break a large feature into independent sub-tasks, assign one worktree each, merge back to `develop` in order of completion.
+
+```plaintext
+develop
+  ├── feat/notifications-model       (Agent 1)
+  ├── feat/notifications-api         (Agent 2)
+  └── feat/notifications-ui          (Agent 3, unblocked after Agent 1 merges)
+```
+
+### Pattern B — Bug Swarm
+
+Multiple bugs reported at once. Each gets its own fix branch and Claude instance. Review + merge independently.
+
+```plaintext
+develop
+  ├── fix/post-scheduling-timezone   (Agent 1)
+  ├── fix/image-upload-memory-leak   (Agent 2)
+  └── fix/oauth-token-refresh        (Agent 3)
+```
+
+### Pattern C — Spike + Implement
+
+Agent 1 runs a research / prototype spike on a throwaway branch.
+Agent 2 waits for the spike findings, then implements on a clean branch.
+
+---
+
+## Guardrails for Agents
+
+- **Never** `rm -rf` or delete files outside the worktree's own directory.
+- **Never** modify the bare repo's `config`, `hooks`, or `packed-refs` directly.
+- **Never** run `git worktree add/remove` from within a worktree — only the orchestrator (human or top-level agent) manages worktree lifecycle.
+- **Always** scope file edits to the modules listed in the task handoff.
+- **Always** run the project's test suite before committing.
+
+---
+
+## Quick Reference Commands
+
+```bash
+# List all active worktrees
+git worktree list
+
+# Add a worktree for a new feature branch (run from inside <repo>.git/)
+git worktree add feat_foo -b feat/foo
+
+# Add a worktree for an existing remote branch
+git worktree add fix_bar origin/fix/bar
+
+# Remove a worktree after merging
+git worktree remove feat_foo
+
+# Prune stale worktree refs (after manual directory deletion)
+git worktree prune
+```
+
+---
+
+## Agent Definition Updates Required
+
+The table below lists every `.agents-brain` file that needs changes to support the worktree workflow, what must change, and why.
+
+### agent-0-orchestrator.md — High impact
+
+| Where                 | Current                                       | Required change                                                                                                                                                      |
+| --------------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Step 0                | Delegates branch creation to agent-4          | Instruct agent-4 (Task 1 + Task 2) to create the worktree and **report back the worktree path**; orchestrator then stores it and passes it to every subsequent agent |
+| Every Task tool spawn | No worktree path in handoff                   | Add `Worktree:` field (value received from agent-4) to every subagent task handoff                                                                                   |
+| Step 5 — end          | "return local repository to `develop` branch" | Instruct agent-4 to remove the worktree (`git worktree remove`) — develop refresh is also handled by agent-4 Task 5                                                  |
+
+### agent-4-git.md — High impact
+
+| Task   | Current                         | Required change                                                                                                                                                                                     |
+| ------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Task 1 | `git pull` on develop           | `git fetch origin` — bare repo has no working tree to pull into                                                                                                                                     |
+| Task 2 | `git checkout -b <type>/<slug>` | Run `git worktree add <type>_<slug> -b <type>/<slug>` from inside `<repo>.git/`; report the resulting worktree path back to the orchestrator                                                        |
+| Task 5 | Push branch                     | Run from inside the worktree directory received from the orchestrator; after push, also pull latest into the `develop` worktree (`git -C <repo>.git/develop pull`) so it is ready for the next task |
+
+### agent-6-reviewer.md — Medium impact
+
+`npm run lint` and `npm run type-check` are currently described as running "from the repository root". With worktrees the bare repo root has no `node_modules`. The agent must `cd` to the worktree path passed by the orchestrator before running any shell command.
+
+### agent-3-tester.md — Medium impact
+
+Same issue as the reviewer: `npm run test` must run from the **worktree root**, not the bare repo root. The agent must use the worktree path from the task handoff explicitly.
+
+### agent-2-coder.md — Low impact
+
+No git or shell commands, but all file reads and writes are implicitly scoped to the worktree. Add one line: _"All paths are relative to the worktree root passed by the orchestrator."_
+
+### agent-1-specs.md, agent-5-security.md — Low impact
+
+No git or shell operations, but both agents write output files to `[task-folder]` which lives inside the worktree. They must receive the `Worktree:` field in their task handoff so they can resolve `[task-folder]` as an absolute path.
+
+---
+
+### Change summary
+
+| Agent file              | Impact | Change type                                                                     |
+| ----------------------- | ------ | ------------------------------------------------------------------------------- |
+| agent-0-orchestrator.md | High   | Worktree lifecycle (create + remove) + task handoff format                      |
+| agent-4-git.md          | High   | Task 1 → fetch, Task 2 → verify, Task 5 → cd to worktree                        |
+| agent-6-reviewer.md     | Medium | Explicit `cd <worktree>` before lint / type-check                               |
+| agent-3-tester.md       | Medium | Explicit `cd <worktree>` before test run                                        |
+| agent-2-coder.md        | Low    | Note about path root                                                            |
+| agent-1-specs.md        | Low    | Receive `Worktree:` in task handoff to resolve `[task-folder]` as absolute path |
+| agent-5-security.md     | Low    | Same as above                                                                   |
+
+---
+
+## Updating Agent Memory
+
+After validating this workflow on a real task, update the project memory file (path shown by Claude at session start) with:
+
+```markdown
+## Worktree Workflow
+
+- Repo is a bare clone; worktrees live **inside** `<repo>.git/` as `<type>_<slug>/`
+- Naming: directory `feat_my-feature` ↔ branch `feat/my-feature`
+- One Claude instance per worktree terminal
+- See CLAUDE-AGENT-WITH-WORKTREE.md on branch ci/add-support-worktree for full protocol
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ docs/prompts/tasks/
 
 ```mermaid
 flowchart TD
-    userRequest([User request<br />docs/prompts/tasks/issue-&lsqb;id&rsqb;-&lsqb;slug&rsqb;/README.md]) --> versioningBranch[Versioning agent<br />Task 1-2: pull develop + create branch]
+    userRequest([User request<br />docs/prompts/tasks/issue-&lsqb;id&rsqb;-&lsqb;slug&rsqb;/README.md]) --> versioningBranch[Versioning agent<br />Task 1-2: fetch origin + create worktree]
     versioningBranch --> specsAgent[Specs agent<br />writes business-specifications.md]
     specsAgent -->|ADR Required → human approves| specsAgent
     specsAgent --> approveSpecs{Human approves<br />business specs?}
@@ -176,7 +176,7 @@ flowchart TD
     approvePR -->|Approved| createPR[gh pr create]
     createPR --> approveMerge{Human approves<br />merge?}
     approveMerge -->|Rejected| prRemainsOpen([PR remains open])
-    approveMerge -->|Approved| mergePR([gh pr merge + return to develop])
+    approveMerge -->|Approved| mergePR([gh pr merge + remove worktree])
 ```
 
 Human approval gates: after specs, after coding, before PR creation, and before merge. The orchestrator retries failed loops up to 3 times before aborting. Agents flag `### ADR Required` in their output files when a new architectural pattern is introduced; the orchestrator surfaces this to the human before proceeding.


### PR DESCRIPTION
## Summary

- **agent-4**: `git pull` → `git fetch origin` (Task 1); `git checkout -b` → `git worktree add` with path reported back to orchestrator (Task 2); pulls `develop` worktree after push (Task 5); new Task 6 for post-merge worktree removal
- **agent-0**: captures `Worktree:` path from agent-4 and threads it through every subagent handoff; Step 5 triggers Task 6 instead of a manual branch switch
- **agent-6, agent-3**: explicit `cd <worktree>` before running lint / type-check / test commands
- **agent-2**: note that all file paths are relative to the worktree root
- **agent-1, agent-5**: document the `Worktree:` field received from the orchestrator
- **CLAUDE.md**: mermaid diagram labels updated to reflect worktree lifecycle
- Add `CLAUDE-AGENT-WORKFLOW-WORKTREE-AND-AGENT-PARALLELISM.md` spec document

## Test plan

- [ ] Verify agent-4 Task 2 creates a worktree directory and reports the path correctly
- [ ] Verify agent-0 passes `Worktree:` to all subagents in task handoffs
- [ ] Verify agent-6 and agent-3 run npm commands from the worktree root, not the bare repo root
- [ ] Verify agent-4 Task 6 removes the worktree and updates `develop` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)