### PR TITLE
ci(agent): improve pipeline robustness and gh command ownership

### DIFF
--- a/.agents-brain/agent-0-orchestrator.md
+++ b/.agents-brain/agent-0-orchestrator.md
@@ -8,6 +8,14 @@ MAX_RETRIES = 3
 
 All sub agents must retry `MAX_RETRIES` at most before notifying human.
 
+## Shell Command Retry Limit
+
+Applies to the orchestrator and all sub agents. Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the human.
+
+## Agent Pipeline Issue Handling
+
+When the user reports a problem with an agent's behaviour or instructions, follow `CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md`. Spawn `.agents-brain/agent-7-pipeline-maintainer.md` to apply the fix in the dedicated worktree, then use the git agent for commit, PR, and cleanup.
+
 ## Pipeline
 
 ### Step 0 — Task Folder and Branching
@@ -130,13 +138,13 @@ Report the branch name and commit message to the user when done.
 
 Use AskUserQuestion to show the user the proposed PR title and description and ask for approval to create the PR. If the user does not approve, stop and report why.
 
-Once approved, create the PR using `gh pr create`.
+Once approved, read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 6 only** (create the PR). Pass `Worktree: [worktree]`. Wait for the subagent to report the PR URL.
 
-Use AskUserQuestion a second time to ask the user for approval to merge the PR. If the user does not approve, stop — the PR remains open for the user to merge manually.
+Use AskUserQuestion a second time to show the user the PR URL and ask for approval to merge. If the user does not approve, stop — the PR remains open for the user to merge manually.
 
-Once approved, run the merge command.
+Once approved, read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 7 only** (merge the PR). Pass `Worktree: [worktree]`.
 
-Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 6 only** (remove the worktree and update develop). Pass `Worktree: [worktree]`.
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 8 only** (remove the worktree and update develop). Pass `Worktree: [worktree]`.
 
 ## Bug Feedback Loop
 

--- a/.agents-brain/agent-1-specs.md
+++ b/.agents-brain/agent-1-specs.md
@@ -50,3 +50,7 @@ The file is a self-contained document for the current run only. Create it at `[t
 Listen to the `[task-folder]/technical-specifications.md` file for `status: review specs` in the last line and process feedback following `### Specifications Need Review`.
 
 Do NOT use horizontal rules (`---`) anywhere in the output file.
+
+## Shell Command Retry Limit
+
+Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/.agents-brain/agent-2-coder.md
+++ b/.agents-brain/agent-2-coder.md
@@ -128,3 +128,7 @@ function isValid(item: Item): boolean {
 ```
 
 Where strict compliance would conflict with framework conventions (e.g. Vue lifecycle hooks, composable conventions following `useXxx` patterns), document the exception in the technical-choices section of `[task-folder]/technical-specifications.md`.
+
+## Shell Command Retry Limit
+
+Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/.agents-brain/agent-3-tester.md
+++ b/.agents-brain/agent-3-tester.md
@@ -11,6 +11,10 @@ Write and run tests that cover:
 
 Use `npm run test` (Vitest) to run the test suite, executed from the **worktree root** passed by the orchestrator (`Worktree:` field). The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Test files are TypeScript (`.spec.ts`), placed alongside source files or in `src/__tests__/`.
 
+## Shell Command Retry Limit
+
+Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately: record the full error output in `[task-folder]/test-results.md` and end the file with `status: failed`.
+
 ## Writing the test-results file
 
 The file is a self-contained document for the current run. Create it at `[task-folder]/test-results.md`. Under it, write a full test report including:

--- a/.agents-brain/agent-4-git.md
+++ b/.agents-brain/agent-4-git.md
@@ -39,7 +39,19 @@ docs: update API usage in README
 
 ### Task 1: Make Sure Local Repository Is Up-to-date
 
-Run `git fetch origin` to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
+First verify the bare repo has `origin` configured:
+
+```bash
+git -C <repo>.git remote -v
+```
+
+If `origin` is missing, add it before fetching:
+
+```bash
+git -C <repo>.git remote add origin https://github.com/<owner>/<repo>.git
+```
+
+Then run `git fetch origin` to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
 
 ### Task 2: Create new branch and worktree
 

--- a/.agents-brain/agent-4-git.md
+++ b/.agents-brain/agent-4-git.md
@@ -97,16 +97,50 @@ If the last line is `status: passed`:
 git -C <repo>.git/develop pull
 ```
 
-### Task 6: Remove worktree (post-merge cleanup)
+### Task 6: Create pull request
+
+Run from the worktree root:
+
+```bash
+gh pr create --base develop --title "<title>" --body "<body>"
+```
+
+- Derive the PR title from `[task-folder]/business-specifications.md` (short imperative summary, ≤70 chars).
+- The PR body must include: a summary of what changed and why, a test plan checklist, and a reference to the issue (`Closes #<issue-id>`).
+- Target branch is always `develop` — never `main`.
+- Report the PR URL back to the orchestrator.
+
+### Task 7: Merge pull request
+
+Run:
+
+```bash
+gh pr merge <pr-url> --squash --delete-branch
+```
+
+- Always squash-merge to keep `develop` history linear.
+- `--delete-branch` removes the remote branch automatically.
+
+### Task 8: Remove worktree (post-merge cleanup)
 
 Run from inside `<repo>.git/` (the bare repository root):
 
 ```bash
+git fetch origin
+git worktree prune
 git worktree remove <type>_<slug>
-git branch -d <type>/<slug>
+git branch -D <type>/<slug>
 ```
 
+Notes:
+- `git worktree prune` must run before `git worktree remove` to clear stale refs when the worktree directory is already empty.
+- Use `-D` (force) instead of `-d` because GitHub squash-merges do not create a merge commit, so git never considers the local branch "fully merged".
+
 Then run `git -C <repo>.git/develop pull` to ensure `develop` reflects the merged commit.
+
+## Shell Command Retry Limit
+
+Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately: report the full error output to the orchestrator and stop.
 
 ## Bug Discovery Rule (applies to all tasks)
 

--- a/.agents-brain/agent-5-security.md
+++ b/.agents-brain/agent-5-security.md
@@ -40,3 +40,7 @@ If the guidelines introduce a new security pattern not yet documented in `docs/d
 Notify the orchestrator so it can pause the pipeline and ask the human to approve the ADR before coding starts.
 
 End the file with `status: ready` as the last line.
+
+## Shell Command Retry Limit
+
+Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/.agents-brain/agent-6-reviewer.md
+++ b/.agents-brain/agent-6-reviewer.md
@@ -10,6 +10,10 @@ Then read every source file listed in the technical spec.
 
 Run `npm run lint` and `npm run type-check` from the **worktree root** passed by the orchestrator (`Worktree:` field). The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their full output in your findings.
 
+## Shell Command Retry Limit
+
+Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately: record the full error output in `[task-folder]/review-results.md` and end the file with `status: changes requested`.
+
 Before reviewing Vue/TypeScript-specific issues, fetch the following reference pages to ground your review in current documentation:
 
 - `https://vuejs.org/guide/essentials/reactivity-fundamentals` — reactivity model

--- a/.agents-brain/agent-7-pipeline-maintainer.md
+++ b/.agents-brain/agent-7-pipeline-maintainer.md
@@ -1,0 +1,49 @@
+# I am a Pipeline Maintainer Agent
+
+I am responsible for editing agent brain files and `CLAUDE*.md` files when a pipeline issue is reported. I do not run code, tests, or git commands — those remain the responsibility of their respective agents.
+
+The orchestrator passes:
+
+- `Issue: [description]` — what went wrong and why
+- `Worktree: [worktree]` — absolute path to the active worktree; all files are resolved under it
+
+## Scope
+
+I may read and edit:
+
+- `.agents-brain/agent-*.md` — agent instruction files
+- `CLAUDE.md` — main project instructions for Claude Code
+- `CLAUDE-*.md` — supplementary workflow and analysis documents at the repo root
+
+I must not edit source code, test files, documentation under `docs/`, or any pipeline artifact under `docs/prompts/tasks/`.
+
+## Workflow
+
+### Step 1 — Understand the issue
+
+Read the issue description passed by the orchestrator. If it references a specific agent file, read it. If the scope is unclear, read all agent files to identify the root cause.
+
+### Step 2 — Identify all files that need updating
+
+List every file that must change. Consider cascading effects: a change to one agent's behaviour may require updating the orchestrator, the analysis documents, or other agents that rely on the same convention.
+
+### Step 3 — Apply changes
+
+Edit each identified file. For every change:
+
+- Apply the minimal fix that resolves the issue — do not refactor unrelated content.
+- If you identify additional gaps beyond the reported issue, list them in your report but do not fix them without explicit instruction.
+
+### Step 4 — Report
+
+Write a summary of every file changed and what was changed, suitable for the git agent to use as a commit message body. Include:
+
+- File path
+- Nature of the change (one sentence)
+- Reason (one sentence)
+
+End your report with `status: ready`.
+
+## Shell Command Retry Limit
+
+Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md
+++ b/CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md
@@ -1,0 +1,72 @@
+# Agent Pipeline Issue Handling
+
+This file documents how to handle issues discovered in the multi-agent pipeline (e.g. broken agent instructions, incorrect git steps, missing edge cases).
+
+## Rule: Never Modify `develop` Directly
+
+The `develop` branch is protected and does not accept direct pushes.
+**All fixes to agent pipeline files must go through a dedicated worktree and a PR.**
+
+## Workflow
+
+### 1. Identify the Issue
+
+The user reports a problem with an agent's behaviour or output (e.g. a git command fails, a step is missing, an edge case is not handled).
+
+### 2. Create a GitHub Issue
+
+Open a GitHub issue describing:
+
+- What went wrong
+- Which agent file(s) are affected
+- What the fix should be
+
+Record the issue number — it becomes the worktree identifier.
+
+### 3. Create a Dedicated Worktree
+
+From inside the bare repository root (`<repo>.git/`):
+
+```bash
+git fetch origin
+git worktree add docs_<slug> -b docs/<slug>
+```
+
+- `<slug>` must be ≤ 30 characters.
+- Use type `docs` for agent instruction files (`.agents-brain/`) and this file.
+- Use type `ci` for workflow or CI config files.
+
+### 4. Spawn the Pipeline Maintainer Agent
+
+Read `.agents-brain/agent-7-pipeline-maintainer.md` and spawn a subagent using the Task tool with that prompt. Pass:
+
+- `Issue: [description of the problem]`
+- `Worktree: [absolute path to the worktree]`
+
+The agent will identify all files that need updating, apply the minimal fix, and report back a summary of changes with `status: ready`.
+
+Claude Code may also suggest improvements beyond what the agent proposes — the user decides what to include.
+
+**Never edit files in `<repo>.git/develop/` directly.**
+
+### 5. Commit via the Git Agent
+
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to stage and commit the changed files. Pass `Worktree: [worktree]`.
+
+Commit rules:
+
+- Files under `.agents-brain/` use commit type and scope `ci(agent)`.
+- Files under `docs/` or at the repo root (`CLAUDE*.md`) use commit type `docs`.
+- Stage only the affected files.
+
+Confirm the commit message with the user before pushing.
+
+### 6. Push and Open a PR
+
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 6** (create PR) and wait for PR URL, then **Task 7** (merge PR) after user approval. Pass `Worktree: [worktree]`.
+
+Target branch: `develop`.
+
+### 7. Post-Merge Cleanup
+
+Read `.agents-brain/agent-4-git.md` and spawn a subagent using the Task tool with that prompt, instructing it to perform **Task 8** (remove worktree and update develop). Pass `Worktree: [worktree]`.

--- a/CLAUDE-WORKFLOW-MAX-RETRIES-GAP.md
+++ b/CLAUDE-WORKFLOW-MAX-RETRIES-GAP.md
@@ -1,0 +1,30 @@
+# MAX_RETRIES Gap Analysis
+
+## Problem
+
+`MAX_RETRIES = 3` is defined in `agent-0-orchestrator.md` and controls **step-level retries** — how many times the orchestrator re-spawns a failing agent (e.g. coder → reviewer → tester loop).
+
+It does **not** control what happens inside a single agent session when a shell command fails or hangs. No retry limit was defined at the command level, so agents running `npm run lint`, `npm run type-check`, or `npm run test` could loop indefinitely retrying the same failing command.
+
+## Affected Agents
+
+All agents. The rule is applied universally as a safety guard — even agents that do not currently run shell commands could do so in future tasks.
+
+| Agent                            | Known shell commands                                                                             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `agent-0-orchestrator.md`        | none (delegates all shell commands to sub agents)                                                |
+| `agent-1-specs.md`               | none currently                                                                                   |
+| `agent-2-coder.md`               | none currently                                                                                   |
+| `agent-3-tester.md`              | `npm run test`                                                                                   |
+| `agent-4-git.md`                 | `git fetch`, `git push`, `git worktree`, `git branch`, `git pull`, `gh pr create`, `gh pr merge` |
+| `agent-5-security.md`            | none currently                                                                                   |
+| `agent-6-reviewer.md`            | `npm run lint`, `npm run type-check`                                                             |
+| `agent-7-pipeline-maintainer.md` | none currently, but might in the future                                                          |
+
+## Fix
+
+A **Shell Command Retry Limit** section was added to each affected agent:
+
+> Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, record the full error output, write the appropriate failure status to your output file, and stop immediately.
+
+This rule is independent of the orchestrator's `MAX_RETRIES`, which remains in effect at the step level.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,10 @@ shadcn-vue components live in `src/components/ui/`. These are copied (not npm-in
 - `docs/decisions/` — Architecture Decision Records (ADR-001 through ADR-006)
 - `docs/prompts/` — Pipeline artifacts per issue (`issue-[id]-[slug]/`): README, specs, technical notes, test results
 
+## Agent Pipeline Issue Handling
+
+When the user reports a problem with an agent's behaviour or instructions, follow `CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md` — never modify `develop` directly.
+
 ## Multi-Agent Pipeline
 
 **When the user provides a feature request, bug fix, or any change, act as the orchestrator:**


### PR DESCRIPTION
## Summary

- Add **shell command retry limit** (max 3 failing commands total) to all 7 agents + orchestrator
- Move `gh pr create` and `gh pr merge` from the orchestrator to the git agent (new Tasks 6 & 7; old Task 6 cleanup becomes Task 8)
- Fix Task 8 worktree cleanup: add `git worktree prune` before remove, use `git branch -D` for squash merges
- Add **agent-7-pipeline-maintainer** — dedicated agent for editing `.agents-brain/` and `CLAUDE*.md` files when pipeline issues are found
- Add `CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md` — full workflow for handling pipeline issues via dedicated worktree
- Add `CLAUDE-WORKFLOW-MAX-RETRIES-GAP.md` — analysis of the shell command retry gap

Closes #81

## Test plan

- [ ] Verify all agent files contain the Shell Command Retry Limit section
- [ ] Verify orchestrator Step 5 delegates PR creation and merge to git agent
- [ ] Verify git agent Tasks 6, 7, 8 are correctly sequenced
- [ ] Verify `CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md` references agent-7 and git agent tasks correctly
- [ ] Verify `CLAUDE.md` references the new workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)