### PR TITLE
docs(pipeline): integrate RTK Token Killer for token optimization

### DIFF
--- a/.claude/agents/agent-0-orchestrator.md
+++ b/.claude/agents/agent-0-orchestrator.md
@@ -110,7 +110,7 @@ Invoke agent-6-reviewer using the Task tool. Pass the following to the subagent:
 - `Task folder: [task-folder]`
 - `Worktree: [worktree]`
 
-The subagent reviews the changed source files against `[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`, runs `/e/rtk/bin/rtk.exe lint` and `npm run type-check` from `[worktree]`, and writes `[task-folder]/review-results.md`.
+The subagent reviews the changed source files against `[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`, runs `rtk lint` and `npm run type-check` from `[worktree]`, and writes `[task-folder]/review-results.md`.
 
 Wait for `[task-folder]/review-results.md` to end with either `status: approved` or `status: changes requested`.
 

--- a/.claude/agents/agent-0-orchestrator.md
+++ b/.claude/agents/agent-0-orchestrator.md
@@ -110,7 +110,7 @@ Invoke agent-6-reviewer using the Task tool. Pass the following to the subagent:
 - `Task folder: [task-folder]`
 - `Worktree: [worktree]`
 
-The subagent reviews the changed source files against `[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`, runs `npm run lint` and `npm run type-check` from `[worktree]`, and writes `[task-folder]/review-results.md`.
+The subagent reviews the changed source files against `[task-folder]/security-guidelines.md` and `[task-folder]/business-specifications.md`, runs `/e/rtk/bin/rtk.exe lint` and `npm run type-check` from `[worktree]`, and writes `[task-folder]/review-results.md`.
 
 Wait for `[task-folder]/review-results.md` to end with either `status: approved` or `status: changes requested`.
 

--- a/.claude/agents/agent-2-coder.md
+++ b/.claude/agents/agent-2-coder.md
@@ -141,9 +141,9 @@ Where strict compliance would conflict with framework conventions (e.g. Vue life
 ## RTK Token Optimization
 
 When running shell commands, prefer rtk equivalents to reduce token usage (use the absolute path since subagents run in isolated bash):
-- `ls` → `/e/rtk/bin/rtk.exe ls`
-- `cat/head/tail <file>` → `/e/rtk/bin/rtk.exe read <file>`
-- `grep/rg <pattern>` → `/e/rtk/bin/rtk.exe grep <pattern>`
+- `ls` → `rtk ls`
+- `cat/head/tail <file>` → `rtk read <file>`
+- `grep/rg <pattern>` → `rtk grep <pattern>`
 
 Prefer the dedicated Read/Glob/Grep tools over shell commands when available.
 

--- a/.claude/agents/agent-2-coder.md
+++ b/.claude/agents/agent-2-coder.md
@@ -138,6 +138,15 @@ function isValid(item: Item): boolean {
 
 Where strict compliance would conflict with framework conventions (e.g. Vue lifecycle hooks, composable conventions following `useXxx` patterns), document the exception in the technical-choices section of `[task-folder]/technical-specifications.md`.
 
+## RTK Token Optimization
+
+When running shell commands, prefer rtk equivalents to reduce token usage (use the absolute path since subagents run in isolated bash):
+- `ls` → `/e/rtk/bin/rtk.exe ls`
+- `cat/head/tail <file>` → `/e/rtk/bin/rtk.exe read <file>`
+- `grep/rg <pattern>` → `/e/rtk/bin/rtk.exe grep <pattern>`
+
+Prefer the dedicated Read/Glob/Grep tools over shell commands when available.
+
 ## Shell Command Retry Limit
 
 Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/.claude/agents/agent-3-test-runner.md
+++ b/.claude/agents/agent-3-test-runner.md
@@ -10,11 +10,13 @@ The orchestrator passes:
 - `Task folder: [task-folder]` — directory where all pipeline artifacts are written
 - `Worktree: [worktree]` — absolute path to the active worktree
 
-Run Vitest from the worktree root using the exact command below. The bare repo root has no `node_modules` — always `cd` to the worktree path first. Use `--run` to prevent Vitest from entering watch mode, which would hang the process.
+Run Vitest from the worktree root using the exact command below. The bare repo root has no `node_modules` — always `cd` to the worktree path first.
 
 ```bash
-cd [worktree] && npm run test -- --run
+cd [worktree] && /e/rtk/bin/rtk.exe vitest run
 ```
+
+`/e/rtk/bin/rtk.exe vitest run` runs Vitest in non-watch mode and shows failures only — saving significant tokens on large test suites.
 
 ## Shell Command Retry Limit
 

--- a/.claude/agents/agent-3-test-runner.md
+++ b/.claude/agents/agent-3-test-runner.md
@@ -13,10 +13,10 @@ The orchestrator passes:
 Run Vitest from the worktree root using the exact command below. The bare repo root has no `node_modules` — always `cd` to the worktree path first.
 
 ```bash
-cd [worktree] && /e/rtk/bin/rtk.exe vitest run
+cd [worktree] && rtk vitest run
 ```
 
-`/e/rtk/bin/rtk.exe vitest run` runs Vitest in non-watch mode and shows failures only — saving significant tokens on large test suites.
+`rtk vitest run` runs Vitest in non-watch mode and shows failures only — saving significant tokens on large test suites.
 
 ## Shell Command Retry Limit
 

--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -47,16 +47,16 @@ Use `rtk` for all supported git and gh commands — it compresses output and red
 
 | Raw command | RTK equivalent |
 |---|---|
-| `git status` | `/e/rtk/bin/rtk.exe git status` |
-| `git diff` | `/e/rtk/bin/rtk.exe git diff` |
-| `git log` | `/e/rtk/bin/rtk.exe git log` |
-| `git add <files>` | `/e/rtk/bin/rtk.exe git add <files>` |
-| `git commit -m "msg"` | `/e/rtk/bin/rtk.exe git commit -m "msg"` |
-| `git push` | `/e/rtk/bin/rtk.exe git push` |
-| `git pull` | `/e/rtk/bin/rtk.exe git pull` |
-| `gh pr list` | `/e/rtk/bin/rtk.exe gh pr list` |
-| `gh pr view <n>` | `/e/rtk/bin/rtk.exe gh pr view <n>` |
-| `gh run list` | `/e/rtk/bin/rtk.exe gh run list` |
+| `git status` | `rtk git status` |
+| `git diff` | `rtk git diff` |
+| `git log` | `rtk git log` |
+| `git add <files>` | `rtk git add <files>` |
+| `git commit -m "msg"` | `rtk git commit -m "msg"` |
+| `git push` | `rtk git push` |
+| `git pull` | `rtk git pull` |
+| `gh pr list` | `rtk gh pr list` |
+| `gh pr view <n>` | `rtk gh pr view <n>` |
+| `gh run list` | `rtk gh run list` |
 
 Commands without an rtk equivalent (`git worktree`, `git fetch`, `git remote`, `git branch`, `git worktree prune`) run as normal git commands.
 

--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -41,6 +41,25 @@ refactor!: drop support for Node 14
 docs: update API usage in README
 ```
 
+## RTK Token Optimization
+
+Use `rtk` for all supported git and gh commands — it compresses output and reduces token usage:
+
+| Raw command | RTK equivalent |
+|---|---|
+| `git status` | `/e/rtk/bin/rtk.exe git status` |
+| `git diff` | `/e/rtk/bin/rtk.exe git diff` |
+| `git log` | `/e/rtk/bin/rtk.exe git log` |
+| `git add <files>` | `/e/rtk/bin/rtk.exe git add <files>` |
+| `git commit -m "msg"` | `/e/rtk/bin/rtk.exe git commit -m "msg"` |
+| `git push` | `/e/rtk/bin/rtk.exe git push` |
+| `git pull` | `/e/rtk/bin/rtk.exe git pull` |
+| `gh pr list` | `/e/rtk/bin/rtk.exe gh pr list` |
+| `gh pr view <n>` | `/e/rtk/bin/rtk.exe gh pr view <n>` |
+| `gh run list` | `/e/rtk/bin/rtk.exe gh run list` |
+
+Commands without an rtk equivalent (`git worktree`, `git fetch`, `git remote`, `git branch`, `git worktree prune`) run as normal git commands.
+
 ## Tasks
 
 ### Task 1: Make Sure Local Repository Is Up-to-date

--- a/.claude/agents/agent-6-reviewer.md
+++ b/.claude/agents/agent-6-reviewer.md
@@ -21,7 +21,7 @@ The orchestrator passes:
 Run **only** the following two commands from the worktree root. The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their output in your findings.
 
 ```bash
-cd [worktree] && /e/rtk/bin/rtk.exe lint          # ESLint — grouped by rule/file, token-optimized
+cd [worktree] && rtk lint          # ESLint — grouped by rule/file, token-optimized
 cd [worktree] && npm run type-check # vue-tsc type check (no rtk equivalent for vue-tsc)
 ```
 

--- a/.claude/agents/agent-6-reviewer.md
+++ b/.claude/agents/agent-6-reviewer.md
@@ -18,7 +18,12 @@ The orchestrator passes:
 - `Task folder: [task-folder]` — directory where all pipeline artifacts are written
 - `Worktree: [worktree]` — absolute path to the active worktree
 
-Run **only** `npm run lint` and `npm run type-check` from the worktree root. The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their full output in your findings.
+Run **only** the following two commands from the worktree root. The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their output in your findings.
+
+```bash
+cd [worktree] && /e/rtk/bin/rtk.exe lint          # ESLint — grouped by rule/file, token-optimized
+cd [worktree] && npm run type-check # vue-tsc type check (no rtk equivalent for vue-tsc)
+```
 
 Do NOT run `npm run test` — that is the test-runner agent's exclusive responsibility.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,18 +43,18 @@ npm run test:coverage    # Generate coverage report
 
 ## RTK Token Optimization
 
-[Rust Token Killer](https://github.com/RustTokenKiller/rtk) is installed at `/e/rtk/bin/rtk.exe`. Use it instead of raw commands to reduce token usage. Always use the absolute path — subagents run in isolated bash where PATH may not include rtk.
+[Rust Token Killer](https://github.com/RustTokenKiller/rtk) is symlinked at `/usr/local/bin/rtk` and available in all MINGW64 bash sessions including subagents. Use it instead of raw commands to reduce token usage.
 
 | Instead of | Use |
 |---|---|
-| `git status / diff / log` | `/e/rtk/bin/rtk.exe git status / diff / log` |
-| `git add / commit / push / pull` | `/e/rtk/bin/rtk.exe git add / commit / push / pull` |
-| `gh pr list / view / issue list / run list` | `/e/rtk/bin/rtk.exe gh ...` |
-| `npm run lint` | `/e/rtk/bin/rtk.exe lint` (run from worktree root) |
-| `npm run test -- --run` | `/e/rtk/bin/rtk.exe vitest run` (run from worktree root) |
-| `ls` | `/e/rtk/bin/rtk.exe ls` |
-| `cat / head / tail <file>` | `/e/rtk/bin/rtk.exe read <file>` |
-| `grep / rg <pattern>` | `/e/rtk/bin/rtk.exe grep <pattern>` |
+| `git status / diff / log` | `rtk git status / diff / log` |
+| `git add / commit / push / pull` | `rtk git add / commit / push / pull` |
+| `gh pr list / view / issue list / run list` | `rtk gh ...` |
+| `npm run lint` | `rtk lint` (run from worktree root) |
+| `npm run test -- --run` | `rtk vitest run` (run from worktree root) |
+| `ls` | `rtk ls` |
+| `cat / head / tail <file>` | `rtk read <file>` |
+| `grep / rg <pattern>` | `rtk grep <pattern>` |
 
 `npm run type-check` (vue-tsc) has no rtk equivalent — keep as-is.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,23 @@ npm run test:ui          # Run tests with browser UI dashboard
 npm run test:coverage    # Generate coverage report
 ```
 
+## RTK Token Optimization
+
+[Rust Token Killer](https://github.com/RustTokenKiller/rtk) is installed at `/e/rtk/bin/rtk.exe`. Use it instead of raw commands to reduce token usage. Always use the absolute path — subagents run in isolated bash where PATH may not include rtk.
+
+| Instead of | Use |
+|---|---|
+| `git status / diff / log` | `/e/rtk/bin/rtk.exe git status / diff / log` |
+| `git add / commit / push / pull` | `/e/rtk/bin/rtk.exe git add / commit / push / pull` |
+| `gh pr list / view / issue list / run list` | `/e/rtk/bin/rtk.exe gh ...` |
+| `npm run lint` | `/e/rtk/bin/rtk.exe lint` (run from worktree root) |
+| `npm run test -- --run` | `/e/rtk/bin/rtk.exe vitest run` (run from worktree root) |
+| `ls` | `/e/rtk/bin/rtk.exe ls` |
+| `cat / head / tail <file>` | `/e/rtk/bin/rtk.exe read <file>` |
+| `grep / rg <pattern>` | `/e/rtk/bin/rtk.exe grep <pattern>` |
+
+`npm run type-check` (vue-tsc) has no rtk equivalent — keep as-is.
+
 Use `netlify dev` (not `npm run dev`) during development to enable the `/api/fetch-article` backend proxy — without it, article fetching will fail due to CORS.
 
 ## Architecture


### PR DESCRIPTION
## Summary

- Add `/e/rtk/bin/rtk.exe` (absolute path) to all Bash-using pipeline agents and `CLAUDE.md` so subagents running in isolated bash sessions can always resolve the binary
- `agent-4-git`: git and gh commands use `rtk git` / `rtk gh` variants (status, diff, log, add, commit, push, pull, pr list/view, run list)
- `agent-3-test-runner`: `npm run test -- --run` → `rtk vitest run` (failures-only output, ~90% token reduction)
- `agent-6-reviewer`: `npm run lint` → `rtk lint` (grouped by rule/file); `npm run type-check` kept as-is (vue-tsc has no rtk equivalent)
- `agent-2-coder`: rtk note for `ls` / `cat` / `grep` fallback shell commands
- `CLAUDE.md`: RTK reference table for main conversation use

## Test plan

- [ ] Trigger pipeline on a new issue and verify agent-4-git uses `rtk git commit/push` without errors
- [ ] Verify agent-3-test-runner output is compact (failures only) via `rtk vitest run`
- [ ] Verify agent-6-reviewer lint output is grouped via `rtk lint`
- [ ] Confirm `npm run type-check` still runs normally (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)