### PR TITLE
docs: sync agent pipeline and restructure CLAUDE.md

### DIFF
--- a/.claude/agents/agent-0-orchestrator.md
+++ b/.claude/agents/agent-0-orchestrator.md
@@ -1,6 +1,6 @@
 ---
 name: agent-0-orchestrator
-description: Orchestrates the full pipeline, delegates to specialist agents via Task tool
+description: Use when the user says "tackle", "work on", "implement", "fix", or "start" a GitHub issue. Orchestrates the full pipeline — specs, security, coding, review, tests, versioning — by delegating to specialist agents via the Task tool.
 model: claude-sonnet-4-6
 tools: Read, Write, Task, AskUserQuestion
 ---
@@ -20,9 +20,13 @@ Applies to the orchestrator and all sub agents. Do not execute more than **3 fai
 
 ## Agent Pipeline Issue Handling
 
-When the user reports a problem with an agent's behaviour or instructions, follow `CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md`.
+When the user reports a problem with an agent's behaviour or instructions, use the `/fix-pipeline` skill.
 
-**Important — agent invocation from the main conversation:** Custom `subagent_type` names (e.g. `"agent-7-pipeline-maintainer"`) are only resolvable when Claude Code natively invokes a `.claude/agents/` agent. From the main conversation (or from a general-purpose subagent), the `Agent` tool only accepts built-in types. Always use `Agent(subagent_type="general-purpose")` and pass the specialist agent's file content as the prompt. See `CLAUDE-ISSUE-TRIGGERING-PIPELINE-MAINTAINER-FROM-MAIN-CONVERSATION.md` for the full procedure.
+**Important — agent invocation from the main conversation:** Custom `subagent_type` names are only resolvable when Claude Code natively invokes a `.claude/agents/` agent. From the main conversation (or from a general-purpose subagent), the `Agent` tool only accepts built-in types. Always use `Agent(subagent_type="general-purpose")` and pass the specialist agent's file content as the prompt.
+
+## Handling subagent questions
+
+If any subagent's output contains a question or request for clarification (i.e. it does not end with a `status:` line), use `AskUserQuestion` to relay the question to the human. Pass the human's answer back to the subagent by re-invoking it (counts toward MAX_RETRIES). Never return a subagent question as your own final output to the main conversation.
 
 ## Pipeline
 
@@ -35,11 +39,16 @@ Build:
 - `slug` = a short (≤ 30 characters) kebab-case summary of the issue title (e.g. `back-button-fix`, `article-extract-error`). Do NOT use the full issue title — long slugs cause path-length failures on Windows (MINGW64) that break subagents running shell commands.
 - `task-folder` = `docs/prompts/tasks/issue-[id of issue]-[slug]/`
 
-Save the user request to `[task-folder]/README.md`.
+Determine `type` from the issue label or nature (e.g. `feat`, `fix`, `docs`, `refactor`).
 
-Invoke agent-4-git using the Task tool, instructing it to perform **Task 1 and Task 2 only** (fetch latest from origin and create the branch + worktree). Do not ask it to commit or push yet.
+Invoke agent-4-git using the Task tool, instructing it to perform **Task 1 and Task 2 only** (fetch latest from origin and create the branch + worktree). Do not ask it to commit or push yet. Pass:
+
+- `Type: [type]`
+- `Slug: [slug]`
 
 Wait for the agent to report back the worktree path (`Worktree: <absolute-path>`). Store this path as `[worktree]` — pass it in the `Worktree:` field of every subsequent subagent task handoff.
+
+**Only after receiving `[worktree]`**, save the user request to `[worktree]/[task-folder]/README.md`. Do NOT create this file or its parent directories before the worktree path is confirmed.
 
 ### Step 1 — Specs
 

--- a/.claude/agents/agent-1-specs.md
+++ b/.claude/agents/agent-1-specs.md
@@ -25,6 +25,12 @@ A good spec describes WHAT the system does: goals, rules, constraints, and obser
 
 Use the Example Mapping method from the Agile community to write specifications.
 
+**Conciseness rules (strictly enforced):**
+- Write at most **1 example per rule**. If the rule is self-evident from its description, omit the example entirely.
+- Integrate edge cases directly into the rule they qualify. Do not create a standalone Edge Cases section.
+- Do not repeat information from CLAUDE.md, existing ADRs, or the README. Reference them by name instead.
+- Target **60 lines maximum** for the output file. Cut rules that only restate technology decisions already captured in CLAUDE.md or ADRs.
+
 Ask up to 10 clarifying questions about architecture, edge cases, and dependencies to the human if needed. **DO NOT TRY TO GUESS**.
 
 Do NOT include any of the following in a spec:

--- a/.claude/agents/agent-2-coder.md
+++ b/.claude/agents/agent-2-coder.md
@@ -147,6 +147,12 @@ When running shell commands, prefer rtk equivalents to reduce token usage (use t
 
 Prefer the dedicated Read/Glob/Grep tools over shell commands when available.
 
+## Composable Caller Responsibility
+
+Composables must never self-trigger data fetching on init. The caller component is always responsible for invoking fetch actions. Never call a fetch action inside a composable's own setup or initialisation — only expose it for the component to call.
+
+Never call a composable inside a plain or async function within another composable. Composables must only be called at the top level of `setup()`. If a composable needs data from another, the caller component calls both in `setup()` and passes the data as a parameter to the action that needs it.
+
 ## Shell Command Retry Limit
 
 Do not execute more than **3 failing shell commands in total** — whether retrying the same command or trying a different one. After 3 failed executions, stop immediately and report the full error output to the orchestrator.

--- a/.claude/agents/agent-3-test-runner.md
+++ b/.claude/agents/agent-3-test-runner.md
@@ -24,30 +24,38 @@ Do not execute more than **3 failing shell commands in total** — whether retry
 
 ## Writing the test-results file
 
-The file is a self-contained document for the current run. Create it at `[task-folder]/test-results.md`. Under it, write a full test report including:
+Create `[task-folder]/test-results.md` using this exact template:
 
-- Which tests were run
-- Which passed and which failed
-- Output or stack traces for any failures
+```markdown
+# Test Results — Issue #[id]: [title]
 
-End the file with either:
+## Test Run
 
-```plaintext
+Command: `npm test` (Vitest vX.Y.Z) from the `[worktree name]` worktree.
+
+## Files Run
+
+All those mentioned in [technical specs](technical-specifications.md).
+
+## Results
+
+<if all tests pass>
+All tests passed. No failures.
+
 ### Test Summary
 
-[test summary]
+[N] test files, [N] tests total — all passed.
+
+- Duration: ~[N] seconds
+<else>
+### Failures
+
+<list each failing test with its stack trace or error output>
+<end-if>
 
 status: passed
 ```
 
-or:
-
-```plaintext
-### Testing failed
-
-[details of test run]
-
-status: failed
-```
-
-The status line must always be the last line of the file.
+Rules:
+- If any tests fail, replace the Results section content with failure details and replace `status: passed` with `status: failed`.
+- The status line must always be the last line of the file.

--- a/.claude/agents/agent-3-test-writer.md
+++ b/.claude/agents/agent-3-test-writer.md
@@ -33,6 +33,8 @@ Cover:
 
 Do NOT reference implementation details (function names, file paths, variable names). Write scenarios against observable behaviour only.
 
+If a spec describes a structural or cleanup task with no runtime observable behaviour (e.g. deleting files, renaming types), do not invent test cases for it. Instead add a note: "No runtime tests — verified by `vue-tsc`."
+
 End the file with `status: ready` as the last line.
 
 ## Pass 2 — After Coding
@@ -48,6 +50,15 @@ Translate each scenario in `test-cases.md` into a `.spec.ts` test using Vitest. 
 Each test must import only from paths confirmed to exist in the implementation files.
 
 Do NOT write tests for scenarios not in `test-cases.md`.
+
+Do NOT write `@ts-expect-error` tests or tests whose sole assertion is `toBeDefined()` on a value that cannot be undefined by construction. Type correctness is the responsibility of `vue-tsc`, not Vitest.
+
+Do NOT write tests that assert the presence or absence of files on disk, verify import resolution, or duplicate what `vue-tsc --build` already catches statically.
+
+Do NOT use `node:fs`, `node:path`, or `__dirname` to load test fixtures. The test environment is browser-like (happy-dom) and Node built-ins are unavailable. Load HTML or text fixtures using Vite's `?raw` suffix instead:
+```ts
+import fixtureHtml from '../../tests/fixtures/MY-FIXTURE.html?raw'
+```
 
 End your report with `status: ready`.
 

--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -52,7 +52,7 @@ Use `rtk` for all supported git and gh commands — it compresses output and red
 | `git log` | `rtk git log` |
 | `git add <files>` | `rtk git add <files>` |
 | `git commit -m "msg"` | `rtk git commit -m "msg"` |
-| `git push` | `rtk git push` |
+| `git push origin <branch>` | `rtk git push origin <branch>` |
 | `git pull` | `rtk git pull` |
 | `gh pr list` | `rtk gh pr list` |
 | `gh pr view <n>` | `rtk gh pr view <n>` |
@@ -64,33 +64,48 @@ Commands without an rtk equivalent (`git worktree`, `git fetch`, `git remote`, `
 
 ### Task 1: Make Sure Local Repository Is Up-to-date
 
+The session runs from the `develop/` worktree. The bare repo root is `..` relative to the CWD.
+
 First verify the bare repo has `origin` configured:
 
 ```bash
-git -C <repo>.git remote -v
+git -C .. remote -v
 ```
 
 If `origin` is missing, add it before fetching:
 
 ```bash
-git -C <repo>.git remote add origin https://github.com/<owner>/<repo>.git
+git -C .. remote add origin https://github.com/<owner>/<repo>.git
 ```
 
-Then run `git fetch origin` to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
+Then fetch to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
+
+First ensure the fetch refspec is configured (bare repos often lack it, causing `fetch` to update only `FETCH_HEAD` and leaving `refs/remotes/origin/*` stale):
+
+```bash
+git -C .. config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git -C .. fetch origin
+```
 
 ### Task 2: Create new branch and worktree
 
-Read the user request file at `[task-folder]/README.md` to understand the nature of the change (feature, fix, or docs).
+The orchestrator passes `Type: <type>` and `Slug: <slug>` directly — use these values. Do NOT read any file or create any directory to determine them.
 
-Determine `<type>` (e.g. `feat`, `fix`, `ci`, `docs`) and `<slug>` from the issue title.
-
-From inside `<repo>.git/` (the bare repository root), run:
+Run from the `develop/` worktree (bare repo root is `..`):
 
 ```bash
-git worktree add <type>_<slug> -b <type>/<slug>
+git -C .. worktree add <type>_<slug> -b <type>/<slug> origin/develop
 ```
 
-The resulting worktree path is `<repo>.git/<type>_<slug>/`. Report this path back to the orchestrator as `Worktree: <absolute-path>` so every subsequent agent can use it.
+The path `<type>_<slug>` is relative to the bare repo root (the `-C ..` directory), so the worktree lands at `<bare-repo>/<type>_<slug>` — i.e. a sibling of `develop/`. Do NOT prefix with `../` (that would place it one level above the bare repo).
+
+Then install dependencies inside the new worktree so subsequent agents can run lint, type-check, and tests:
+
+```bash
+cd <type>_<slug> && npm install
+```
+
+Resolve the absolute path of the new worktree and report it back to the orchestrator as `Worktree: <absolute-path>` so every subsequent agent can use it.
 
 ### Task 3: Commit specs output
 
@@ -137,7 +152,7 @@ If the last line is `status: passed`:
 - Stage the test files introduced or modified and `[task-folder]/test-results.md`.
 - Write a meaningful commit message that summarises the change based on `[task-folder]/business-specifications.md` within Git recommended message length. Put anything beyond the commit message limit into the commit description.
 - Commit on the current feature branch — never commit directly to develop or main.
-- Push the branch to origin.
+- Push the branch to origin: `rtk git push origin <branch-name>`. Worktree branches have no upstream set, so always specify the remote and branch name explicitly.
 
 ### Task 6: Create pull request
 
@@ -154,10 +169,10 @@ gh pr create --base develop --title "<title>" --body "<body>"
 
 ### Task 7: Merge pull request
 
-Run:
+Must run from the bare repo root (not from inside any worktree) to avoid `gh` attempting a local `git switch develop` after merging, which fails because `develop` is already checked out in its own worktree.
 
 ```bash
-gh pr merge <pr-url> --rebase --delete-branch
+cd .. && gh pr merge <pr-url> --rebase --delete-branch
 ```
 
 - Always rebase-merge to keep `develop` history linear (the repository does not allow squash or merge commits).
@@ -165,20 +180,26 @@ gh pr merge <pr-url> --rebase --delete-branch
 
 ### Task 8: Remove worktree (post-merge cleanup)
 
-Run from inside `<repo>.git/` (the bare repository root):
+Run from the bare repo root (`..` relative to the `develop/` worktree):
 
 ```bash
-git fetch origin
-git worktree prune
-git worktree remove <type>_<slug>
-git branch -D <type>/<slug>
+git -C .. fetch origin
+git -C .. worktree remove --force <type>_<slug>
+git -C .. worktree prune
+git -C .. branch -D <type>/<slug>
 ```
 
 Notes:
-- `git worktree prune` must run before `git worktree remove` to clear stale refs when the worktree directory is already empty.
-- Use `-D` (force) instead of `-d` because GitHub squash-merges do not create a merge commit, so git never considers the local branch "fully merged".
+- Run `git worktree remove --force` **before** `git worktree prune`. Prune deregisters stale entries first; if the worktree directory still exists but is deregistered, a subsequent `remove` will fail with a permission error.
+- `--force` handles Windows file-lock edge cases where git would otherwise refuse to delete the directory.
+- If the worktree directory still exists on disk after `git worktree remove --force` (e.g. because git already deregistered it in a prior run), delete it manually: `rm -rf <absolute-worktree-path>`.
+- Use `-D` (force) instead of `-d` on `git branch` because GitHub rebase-merges do not create a merge commit, so git never considers the local branch "fully merged".
 
-Then run `git -C <repo>.git/develop pull origin develop` to ensure `develop` reflects the merged commit.
+Then pull latest into `develop/` to ensure it reflects the merged commit:
+
+```bash
+git pull origin develop
+```
 
 ## Shell Command Retry Limit
 

--- a/.claude/agents/agent-5-security.md
+++ b/.claude/agents/agent-5-security.md
@@ -29,7 +29,13 @@ Each rule must state:
 
 - **What** must be enforced
 - **Where** (which file or layer it applies to)
-- **Why** (the attack vector or risk it mitigates)
+- **Why** (the attack vector or risk it mitigates — one sentence max)
+
+**Conciseness rules (strictly enforced):**
+- Skip any scope area (dependencies, secrets, CORS, etc.) not touched by this feature. Do not write "N/A" rules.
+- Do not include rules already enforced project-wide by an existing ADR — cite the ADR by number if it is relevant.
+- Do not restate constraints already present in `business-specifications.md`.
+- Target **4–6 rules maximum**. A feature with a small attack surface may only need 2–3.
 
 Do NOT prescribe implementation details. No function signatures, no code snippets, no variable names. State the constraint and the reason.
 

--- a/.claude/agents/agent-6-reviewer.md
+++ b/.claude/agents/agent-6-reviewer.md
@@ -18,7 +18,11 @@ The orchestrator passes:
 - `Task folder: [task-folder]` — directory where all pipeline artifacts are written
 - `Worktree: [worktree]` — absolute path to the active worktree
 
-Run **only** the following two commands from the worktree root. The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their output in your findings.
+Run **only** the following two commands from the worktree root. The bare repo root has no `node_modules` — always `cd` to the worktree path before running any shell command. Include their output in your findings. Do NOT inspect `package.json` or verify scripts exist first — run them directly.
+
+The scripts are guaranteed to exist (from `package.json`):
+- `"lint": "eslint . --fix"`
+- `"type-check": "vue-tsc --build"`
 
 ```bash
 cd [worktree] && rtk lint          # ESLint — grouped by rule/file, token-optimized
@@ -36,7 +40,7 @@ Before reviewing Vue/TypeScript-specific issues, fetch the following reference p
 - `https://vuejs.org/guide/essentials/reactivity-fundamentals` — reactivity model
 - `https://vuejs.org/guide/reusability/composables` — composable conventions
 - `https://vuejs.org/guide/typescript/composition-api` — TypeScript + Vue patterns
-- `https://developer.mozilla.org/en-US/docs/Web/API/URL` — URL API (used in `utm.ts`)
+- `https://developer.mozilla.org/en-US/docs/Web/API/URL` — URL API (used for URL construction and validation)
 
 ## Review checklist
 
@@ -50,7 +54,7 @@ Before reviewing Vue/TypeScript-specific issues, fetch the following reference p
 - Vue/TypeScript-specific issues:
 
   Reactivity pitfalls:
-  - Destructuring a reactive object loses reactivity: `const { title } = useArticleState()` silently breaks; use `toRefs()` or access as `state.title`
+  - Destructuring a reactive object loses reactivity: `const { value } = useMyComposable()` silently breaks; use `toRefs()` or access as `state.value`
   - Watching a reactive property directly: `watch(state.count, ...)` never triggers; use a getter `watch(() => state.count, ...)`
   - Mutating a prop in-place instead of emitting an event
   - Calling `reactive()` on a primitive value
@@ -68,26 +72,53 @@ Before reviewing Vue/TypeScript-specific issues, fetch the following reference p
 
 ## Writing the review-results file
 
-Create `[task-folder]/review-results.md`.
+Create `[task-folder]/review-results.md` using this exact template:
 
-Include the full output of `npm run lint` and `npm run type-check`.
+```markdown
+# Review Results — Issue #[id]: [title]
 
-If findings exist, list every finding with:
+## Commands Run
 
-- File path and line reference
-- Which checklist rule it violates
-- A fix direction (no code)
+- `npm run lint` output
 
-End with:
+<if any lint errors in changed files, list them in a fenced code block>
 
-```plaintext
-status: changes requested
+```
+<content>
 ```
 
-If no findings remain, write a brief summary of what was reviewed. End with:
+<else>
+None of the changed files (see [technical specs](technical-specifications.md)) produced lint errors.
+<end-if>
 
-```plaintext
+### `npm run type-check` output
+
+<if any type errors, list them in a fenced code block>
+
+```
+<content>
+```
+
+<else>
+Type-check passes with zero errors.
+<end-if>
+
+## Checklist
+
+<if any checklist violation, list details per failing item>
+<else>
+- **Security guidelines:** ✓
+- **Object Calisthenics:** ✓
+- **Business spec compliance:** ✓
+- **Vue/TypeScript-specific issues:** ✓
+- **No dead code or unused imports:** ✓
+- **Naming clarity:** ✓
+<end-if>
+
 status: approved
 ```
 
-The status line must always be the last line of the file.
+Rules:
+- Do NOT add a summary section.
+- If findings exist, replace `status: approved` with `status: changes requested`.
+- The status line must always be the last line of the file.

--- a/.claude/commands/fix-pipeline.md
+++ b/.claude/commands/fix-pipeline.md
@@ -1,0 +1,81 @@
+A pipeline issue has been reported: $ARGUMENTS
+
+Follow this workflow to fix it.
+
+## What NOT to do
+
+- Never directly edit files in `develop/` from the main conversation
+- Never fix pipeline issues inline during a pipeline run for another issue — this must be a separate worktree
+- ALWAYS use `subagent_type="general-purpose"`
+
+## Step 1 — Create a GitHub issue
+
+Use `gh issue create` to record:
+
+- What went wrong
+- Which agent or file(s) are affected
+- What the fix should be
+
+Record the issue number as `[id]` and derive a slug (≤ 30 chars, kebab-case).
+
+## Step 2 — Create a dedicated worktree
+
+The session runs from `develop/`. The bare repo root is `..`.
+
+```bash
+git -C .. fetch origin
+git -C .. worktree add ci_<slug> -b ci/<slug> origin/develop
+```
+
+Record the resulting worktree absolute path as `[worktree]`.
+
+## Step 3 — Apply the fix
+
+Read and edit the affected files directly in the main conversation. You may read and edit:
+
+- `[worktree]/.claude/agents/agent-*.md` — agent instruction files
+- `[worktree]/CLAUDE.md` — main project instructions
+- `[worktree]/CLAUDE-*.md` — supplementary workflow documents
+
+Do not edit source code, test files, or pipeline artifacts under `docs/prompts/tasks/`.
+
+For every change:
+
+- Apply the minimal fix that resolves the issue
+- Consider cascading effects across other agents that rely on the same convention
+- List any additional gaps you find but do not fix them without explicit instruction
+
+## Step 4 — Commit
+
+Stage only the affected files and commit using conventional commits:
+
+- Files under `.claude/agents/` → `ci(agent): <message>`
+- Files at the repo root (`CLAUDE*.md`) → `docs: <message>`
+
+Use `rtk git add <files>` and `rtk git commit -m "..."`.
+
+## Step 5 — Push and open a PR
+
+```bash
+rtk git push origin ci/<slug>
+gh pr create --base develop --title "<title>" --body "<body with Closes #[id]>"
+```
+
+Show the user the PR URL and ask for approval to merge.
+
+## Step 6 — Merge and clean up
+
+Once approved, remove the worktree first (so the branch is free), then merge from the bare repo root:
+
+```bash
+git -C .. worktree remove --force ci_<slug>
+git -C .. worktree prune
+cd .. && gh pr merge <pr-url> --rebase --delete-branch
+git -C .. fetch origin
+```
+
+Then pull latest into `develop/`:
+
+```bash
+git pull --rebase origin develop
+```

--- a/.claude/commands/tackle.md
+++ b/.claude/commands/tackle.md
@@ -1,0 +1,5 @@
+Tackle GitHub issue $ARGUMENTS using the multi-agent pipeline.
+
+Read `.claude/agents/agent-0-orchestrator.md`, then invoke it as a general-purpose agent via the Agent tool, passing the full file content as the prompt along with the issue number: $ARGUMENTS.
+
+The orchestrator will run the full pipeline: specs → security → test cases → coding → review → tests → versioning → PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,107 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Project Overview
+
+A Social Media Sharing Assistant that automates content extraction from blog articles and generates platform-specific posts for X, LinkedIn, Medium, and Substack.
+
+**Workflow:** URL input → Netlify Function fetches HTML (CORS proxy) → HTML parsed and article data extracted → Platform-specific content generated → User copies content per platform.
+
+## Architecture
+
+### Project-specific
+
+#### Key Constraints
+
+The Netlify Function (`netlify/functions/fetch-article.ts`) only whitelists two domains: `iamjeremie.me` and `jeremielitzler.fr`. All other URLs are rejected. This is by design.
+
+#### State Management
+
+State is managed via a **module-level singleton composable** (`src/composables/useArticleState.ts`) — not Pinia. A module-level `ref` is shared across all components that import the composable. See ADR-002 for rationale.
+
+`ExtractionState` tracks `status` as one of: `'idle' | 'loading' | 'missing-introduction' | 'success' | 'error'`. The `missing-introduction` status triggers a manual input fallback UI (`ManualIntroduction.vue`).
+
+#### Data Flow
+
+1. `ArticleInput.vue` → triggers `useArticleExtractor.ts`
+2. `useArticleExtractor.ts` → calls `/.netlify/functions/fetch-article?url=...` → parses HTML via `DOMParser` → calls pure functions in `htmlExtractor.ts` → updates shared state via `useArticleState.ts`
+3. `src/pages/index.vue` → reads state and conditionally renders input, manual intro fallback, or success/platform content
+
+#### HTML Extraction Selectors (`src/utils/htmlExtractor.ts`)
+
+Pure functions targeting these CSS selectors on the fetched blog HTML:
+
+- Title: `.article-title a`
+- Description: `.article-subtitle`
+- Image URL: `meta[name="twitter:image"]` content attribute (full absolute URL)
+- Image alt: `.article-header .article-image a img` alt attribute
+- Introduction: All `<p>`, `<pre>`, `<ul>`, and `<blockquote>` tags before the first `<h2>` in `.article-content`, preserved in source order
+- Categories: `<header class="article-category"> a`
+- Tags: `<section class="article-tags"> a`
+- Follow-me snippet: second-to-last child of `.article-content`; if it is a `div.jli-notice.jli-notice-tip`, the inner `<p class="jli-notice-title">` is replaced with `<h2 class="jli-notice-title">`
+- Image credit: Last `<p>` starting with "Photo by" / "Photo de"
+- Blog detection: Derived from URL domain
+
+#### Platform Content Types (`src/types/article.ts`)
+
+`Platform` = `'X' | 'LinkedIn' | 'Medium' | 'Substack'`
+
+Each platform has its own content interface: `XContent`, `LinkedInContent`, `MediumContent`, `SubstackContent`.
+
+#### UTM Links
+
+`src/utils/utm.ts` exports `generateUTMLink(url, platform)` — adds `utm_medium=social` and `utm_source={platform}` query params. Used when generating platform content links.
+
+### Common
+
+#### Stack
+
+- Vue 3 Composition API with `<script setup lang="ts">` always
+- File-based routing via `unplugin-vue-router`. Pages live in `src/pages/`
+- Vue Composition API functions (`ref`, `computed`, `watch`, etc.), Vue Router hooks, and all components under `src/components/**` are auto-imported — no explicit import statements needed in `.vue` files. Configured in `vite.config.ts`
+- shadcn-vue components live in `src/components/ui/`. These are copied (not npm-installed) and can be customized directly
+
+#### Code Conventions
+
+- Composables in `src/composables/` prefixed with `use`
+- Utility functions in `src/utils/` — pure functions, no Vue dependencies
+- **Styling**: always use Tailwind CSS utility classes. Write custom CSS (inline `style` attributes, `<style>` blocks, or `.css` files) only when no Tailwind utility class covers the need — and add a comment explaining why
+
+#### Naming Conventions
+
+- Components: PascalCase (`ArticleInput.vue`)
+- Composables: camelCase with `use` prefix (`useArticleState.ts`)
+- Types/Interfaces: PascalCase (`Platform`, `XContent`)
+- Utils: camelCase (`htmlExtractor.ts`, `utm.ts`)
+- Constants: UPPER_SNAKE_CASE
+- Test files: `*.spec.ts` suffix
+
+#### Testing Conventions
+
+- Use Vitest + @vue/test-utils
+- Co-locate test files next to source files or in `src/__tests__/`
+- Naming: `*.spec.ts` for all tests
+- Coverage targets:
+  - Composables: 100% (critical state management)
+  - Utils: 100% (pure functions, easy to test)
+  - Components: 80%+ (focus on logic, not styling)
+- All tests must pass before merging
+
+When saving HTML files for test fixtures, always clean them up to prevent happy-dom from fetching external resources during tests (ECONNREFUSED in CI):
+
+```bash
+cd tests/fixtures && for file in *.html; do
+  sed -i '/<link rel="stylesheet"/d' "$file"
+  sed -i '/<script/d; /<\/script>/d' "$file"
+done
+```
+
+## Documentation
+
+- `docs/specs/` — Project specifications and requirements (FR-1 through FR-6)
+- `docs/decisions/` — Architecture Decision Records (ADR-001 through ADR-006)
+- `docs/prompts/` — Pipeline artifacts per issue; see `docs/prompts/README.md` for the full pipeline reference
+
 ## Who Is Claude Code
 
 It is a senior engineer following Git Flow strategy, suggesting performant, secure and clean solutions.
@@ -18,7 +119,60 @@ No need to confirm file creation or modification, but confirm content is OK with
 
 No need to congratulate or use language that use unnecessary output tokens. Go to the point.
 
-## Commands
+## Critical Rules
+
+1. **Pipeline-first**: When asked to tackle/work on/implement/fix a GitHub issue, always use the `/tackle` skill. Never do git operations (branch, checkout, worktree) directly from the main conversation. All code changes go through the pipeline in a worktree.
+2. **No hardcoded paths**: Never hardcode absolute paths or worktree-specific paths (e.g. `develop/`, `feat_foo/`) in any `.md` file under `.claude/`. Absolute paths break portability across machines; worktree paths are runtime values passed by the orchestrator, not constants. Always use placeholders (`[worktree]`, `[task-folder]`) or derive paths at runtime.
+3. **Spec-first**: Before implementing anything, read the relevant spec files.
+4. **ADR-first**: Before making any architectural decision, provide brief context why an ADR is needed before suggesting the full ADR. Once confirmed, create it in `docs/decisions/` and always update the index at `docs/decisions/README.md`.
+5. **Type-first**: Define or update types in `src/types/` before implementing logic that uses them.
+
+## Setup
+
+Claude Code must be opened from the `develop/` worktree, not the bare repo root. If you detect the working directory is the bare repo root (i.e. no `src/`, `package.json`, or `.claude/commands/` at the root), warn the user:
+
+> You appear to have opened Claude Code from the bare repo root. Skills and agents may not be discovered correctly. Please restart from the `develop/` directory:
+>
+> ```
+> cd develop && claude
+> ```
+
+## Context to Read
+
+Always read before starting any task:
+
+- `docs/prompts/workspace-context.md` — current phase, completed work, open decisions
+
+Read when relevant:
+
+- ADRs in `docs/decisions/` — before touching a decided area
+
+## When You Are Unsure
+
+- Flag it explicitly rather than assuming
+- Propose two options with trade-offs and ask for a decision
+- If a spec is ambiguous, quote the ambiguous part and ask for clarification
+- Never silently make a decision that affects architecture or data shape
+
+## Development commands
+
+### Prerequisites 
+
+```bash
+# Install dependencies
+npm install
+
+# Start local dev server (Netlify Dev handles both frontend and functions)
+npx netlify dev
+
+# Build for production
+npx netlify build
+
+# Run tests
+npm test
+```
+
+### While developping
 
 ```bash
 # Development
@@ -35,174 +189,73 @@ npm run type-check   # Run vue-tsc type checking
 npm run lint         # Run ESLint with auto-fix
 npm run format       # Run Prettier formatting
 
-# Testing
+# Run tests
 npm run test             # Run all Vitest unit tests
 npm run test:ui          # Run tests with browser UI dashboard
 npm run test:coverage    # Generate coverage report
 ```
 
-## RTK Token Optimization
+Use `netlify dev` (not `npm run dev`) during development to enable the `/api/fetch-article` backend proxy — without it, article fetching will fail due to CORS.
 
-[Rust Token Killer](https://github.com/RustTokenKiller/rtk) is symlinked at `/usr/local/bin/rtk` and available in all MINGW64 bash sessions including subagents. Use it instead of raw commands to reduce token usage.
+## Shell commands — use `rtk` wrappers
 
-| Instead of | Use |
-|---|---|
-| `git status / diff / log` | `rtk git status / diff / log` |
-| `git add / commit / push / pull` | `rtk git add / commit / push / pull` |
-| `gh pr list / view / issue list / run list` | `rtk gh ...` |
-| `npm run lint` | `rtk lint` (run from worktree root) |
-| `npm run test -- --run` | `rtk vitest run` (run from worktree root) |
-| `ls` | `rtk ls` |
-| `cat / head / tail <file>` | `rtk read <file>` |
-| `grep / rg <pattern>` | `rtk grep <pattern>` |
+**Always** use `rtk` for the commands listed below — never the bare equivalent. These are the commands auto-approved in `.claude/settings.local.json`; running them without `rtk` will trigger a permission prompt on every call.
+
+### Git
+
+```bash
+rtk git status          # compact status
+rtk git log -n 10       # one-line commits
+rtk git diff            # condensed diff
+rtk git add             # -> "ok"
+rtk git commit -m "msg" # -> "ok abc1234"
+rtk git push            # -> "ok main"
+rtk git pull            # -> "ok 3 files +10 -2"
+```
+
+### GitHub CLI
+
+```bash
+rtk gh pr list          # compact PR listing
+rtk gh pr view 42       # PR details + checks
+rtk gh issue list       # compact issue listing
+rtk gh run list         # workflow run status
+```
+
+### Build & lint
+
+```bash
+rtk tsc                 # TypeScript errors grouped by file
+rtk lint                # ESLint grouped by rule/file
+rtk err npm run build   # errors/warnings only
+rtk vitest run          # failures only
+```
 
 `npm run type-check` (vue-tsc) has no rtk equivalent — keep as-is.
 
-Use `netlify dev` (not `npm run dev`) during development to enable the `/api/fetch-article` backend proxy — without it, article fetching will fail due to CORS.
+### Files & search
 
-## Architecture
+```bash
+rtk ls .                # token-optimized directory tree
+rtk read file.ts        # smart file reading
+rtk find "*.ts" .       # compact find results
+rtk grep "pattern" .    # grouped search results
+rtk diff file1 file2    # condensed diff
+```
 
-### Purpose
+### Package managers
 
-A Social Media Sharing Assistant that automates content extraction from blog articles and generates platform-specific posts for X, LinkedIn, Medium, and Substack.
+```bash
+rtk pnpm list           # compact dependency tree
+```
 
-**Workflow:** URL input → Netlify Function fetches HTML (CORS proxy) → HTML parsed and article data extracted → Platform-specific content generated → User copies content per platform.
+### Token savings
 
-### Key Constraints
-
-The Netlify Function (`netlify/functions/fetch-article.ts`) only whitelists two domains: `iamjeremie.me` and `jeremielitzler.fr`. All other URLs are rejected. This is by design.
-
-### State Management
-
-State is managed via a **module-level singleton composable** (`src/composables/useArticleState.ts`) — not Pinia. A module-level `ref` is shared across all components that import the composable. See ADR-002 for rationale.
-
-`ExtractionState` tracks `status` as one of: `'idle' | 'loading' | 'missing-introduction' | 'success' | 'error'`. The `missing-introduction` status triggers a manual input fallback UI (`ManualIntroduction.vue`).
-
-### Data Flow
-
-1. `ArticleInput.vue` → triggers `useArticleExtractor.ts`
-2. `useArticleExtractor.ts` → calls `/.netlify/functions/fetch-article?url=...` → parses HTML via `DOMParser` → calls pure functions in `htmlExtractor.ts` → updates shared state via `useArticleState.ts`
-3. `src/pages/index.vue` → reads state and conditionally renders input, manual intro fallback, or success/platform content
-
-### HTML Extraction Selectors (`src/utils/htmlExtractor.ts`)
-
-Pure functions targeting these CSS selectors on the fetched blog HTML:
-
-- Title: `.article-title a`
-- Description: `.article-subtitle`
-- Image URL: `meta[name="twitter:image"]` content attribute (full absolute URL)
-- Image alt: `.article-header .article-image a img` alt attribute
-- Introduction: All `<p>`, `<pre>`, `<ul>`, and `<blockquote>` tags before the first `<h2>` in `.article-content`, preserved in source order
-- Categories: `<header class="article-category"> a`
-- Tags: `<section class="article-tags"> a`
-- Follow-me snippet: second-to-last child of `.article-content`; if it is a `div.jli-notice.jli-notice-tip`, the inner `<p class="jli-notice-title">` is replaced with `<h2 class="jli-notice-title">`
-- Image credit: Last `<p>` starting with "Photo by" / "Photo de"
-- Blog detection: Derived from URL domain
-
-### Platform Content Types (`src/types/article.ts`)
-
-`Platform` = `'X' | 'LinkedIn' | 'Medium' | 'Substack'`
-
-Each platform has its own content interface: `XContent`, `LinkedInContent`, `MediumContent`, `SubstackContent`.
-
-### Routing
-
-File-based routing via `unplugin-vue-router`. Pages live in `src/pages/`. Currently only `index.vue` exists.
-
-### Auto-imports
-
-Vue Composition API functions (`ref`, `computed`, `watch`, etc.), Vue Router hooks, and all components under `src/components/**` are auto-imported — no explicit import statements needed in `.vue` files. Configured in `vite.config.ts`.
-
-### UI Components
-
-shadcn-vue components live in `src/components/ui/`. These are copied (not npm-installed) and can be customized directly.
-
-### UTM Links
-
-`src/utils/utm.ts` exports `generateUTMLink(url, platform)` — adds `utm_medium=social` and `utm_source={platform}` query params. Used when generating platform content links.
-
-## Documentation
-
-- `docs/specs/` — Project specifications and requirements (FR-1 through FR-6)
-- `docs/decisions/` — Architecture Decision Records (ADR-001 through ADR-006)
-- `docs/prompts/` — Pipeline artifacts per issue (`issue-[id]-[slug]/`): README, specs, technical notes, test results
+```bash
+rtk gain                # summary stats
+rtk discover            # find missed savings opportunities
+```
 
 ## Agent Pipeline Issue Handling
 
-When the user reports a problem with an agent's behaviour or instructions, follow `CLAUDE-AGENT-WORFLOW-ISSUES-HANDLING.md` — never modify `develop` directly.
-
-## Multi-Agent Pipeline
-
-**When the user provides a feature request, bug fix, or any change, act as the orchestrator:**
-
-1. Save the request to `docs/prompts/tasks/issue-[id of issue]-[slug]/README.md`.
-2. Follow the pipeline in `.claude/agents/agent-0-orchestrator.md` step by step.
-
-The user never needs to run a command — just describe what they want and the pipeline starts.
-
-### Task folder structure
-
-All pipeline artifacts for a given task live in one folder:
-
-```
-docs/prompts/tasks/
-  issue-[id of issue]-[slug]/
-    README.md                    ← user request (input)
-    business-specifications.md   ← specs agent output
-    security-guidelines.md       ← security agent output
-    test-cases.md                ← test-writer agent output (pass 1)
-    technical-specifications.md  ← coder agent output
-    review-results.md            ← reviewer agent output
-    test-results.md              ← test-runner agent output
-```
-
-`docs/prompts/tasks/` is a co-authored AI-human artifact space: humans provide the request, agents generate and validate the specs and implementation notes. This is distinct from `docs/specs/` (requirements) and `docs/decisions/` (ADRs), which are maintained by humans.
-
-### Agents and their prompt files
-
-| Agent         | Prompt                                    | Reads                                                                                                          | Writes                                          |
-| ------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| Specification | `.claude/agents/agent-1-specs.md`         | `[task-folder]/README.md`                                                                                      | `[task-folder]/business-specifications.md`      |
-| Security      | `.claude/agents/agent-5-security.md`      | `[task-folder]/business-specifications.md`                                                                     | `[task-folder]/security-guidelines.md`          |
-| Test Writer   | `.claude/agents/agent-3-test-writer.md`   | `[task-folder]/business-specifications.md`, `[task-folder]/security-guidelines.md` (pass 1); `[task-folder]/test-cases.md`, `[task-folder]/technical-specifications.md` (pass 2) | `[task-folder]/test-cases.md` (pass 1); `.spec.ts` files (pass 2) |
-| Coder         | `.claude/agents/agent-2-coder.md`         | `[task-folder]/business-specifications.md`, `[task-folder]/security-guidelines.md`, `[task-folder]/test-cases.md` | `[task-folder]/technical-specifications.md`  |
-| Reviewer      | `.claude/agents/agent-6-reviewer.md`      | `[task-folder]/technical-specifications.md`, `[task-folder]/security-guidelines.md`, `[task-folder]/business-specifications.md` | `[task-folder]/review-results.md` |
-| Test Runner   | `.claude/agents/agent-3-test-runner.md`   | `[task-folder]/technical-specifications.md`                                                                    | `[task-folder]/test-results.md`                 |
-| Versioning    | `.claude/agents/agent-4-git.md`           | `[task-folder]/business-specifications.md`, `[task-folder]/test-results.md`                                   | git history                                     |
-
-### Pipeline flow
-
-```mermaid
-flowchart TD
-    userRequest([User request<br />docs/prompts/tasks/issue-&lsqb;id&rsqb;-&lsqb;slug&rsqb;/README.md]) --> versioningBranch[Versioning agent<br />Task 1-2: fetch origin + create worktree]
-    versioningBranch --> specsAgent[Specs agent<br />writes business-specifications.md]
-    specsAgent -->|ADR Required → human approves| specsAgent
-    specsAgent --> approveSpecs{Human approves<br />business specs?}
-    approveSpecs -->|Rejected| stoppedAfterSpecs([Pipeline stopped])
-    approveSpecs -->|Approved| versioningCommitSpecs[Versioning agent<br />Task 3: commit business-specifications.md]
-    versioningCommitSpecs --> securityAgent[Security agent<br />writes security-guidelines.md]
-    securityAgent -->|ADR Required → human approves| securityAgent
-    securityAgent --> versioningCommitSecurity[Versioning agent<br />Task 3.5: commit security-guidelines.md]
-    versioningCommitSecurity --> testWriterPass1[Test Writer agent (pass 1)<br />writes test-cases.md]
-    testWriterPass1 --> versioningCommitTestCases[Versioning agent<br />Task 3.7: commit test-cases.md]
-    versioningCommitTestCases --> coderAgent[Coder agent<br />writes technical-specifications.md]
-    coderAgent -->|status: review specs → loop back| specsAgent
-    coderAgent --> reviewerAgent[Reviewer agent<br />runs lint + type-check + writes review-results.md]
-    reviewerAgent -->|status: changes requested → loop back| coderAgent
-    reviewerAgent -->|ADR Required → human approves| reviewerAgent
-    reviewerAgent --> approveTechnicalSpecs{Human approves<br />technical specs?}
-    approveTechnicalSpecs -->|Rejected| stoppedAfterReview([Pipeline stopped])
-    approveTechnicalSpecs -->|Approved| versioningCommitCode[Versioning agent<br />Task 4: commit source files + review-results.md]
-    versioningCommitCode --> testWriterPass2[Test Writer agent (pass 2)<br />writes .spec.ts files]
-    testWriterPass2 --> testRunnerAgent[Test Runner agent<br />runs npm test + writes test-results.md]
-    testRunnerAgent -->|status: failed → loop back| coderAgent
-    testRunnerAgent --> versioningCommitTests[Versioning agent<br />Task 5: commit test files + push branch]
-    versioningCommitTests --> approvePR{Human approves<br />PR creation?}
-    approvePR -->|Rejected| stoppedBeforePR([Pipeline stopped])
-    approvePR -->|Approved| createPR[gh pr create]
-    createPR --> approveMerge{Human approves<br />merge?}
-    approveMerge -->|Rejected| prRemainsOpen([PR remains open])
-    approveMerge -->|Approved| mergePR([gh pr merge + remove worktree])
-```
-
-Human approval gates: after specs, after coding, before PR creation, and before merge. The orchestrator retries failed loops up to 3 times before aborting. Agents flag `### ADR Required` in their output files when a new architectural pattern is introduced; the orchestrator surfaces this to the human before proceeding.
+When the user reports a problem with an agent's behaviour or instructions, use the `/fix-pipeline` skill.

--- a/docs/prompts/README.md
+++ b/docs/prompts/README.md
@@ -1,0 +1,77 @@
+# Pipeline Documentation
+
+This folder holds all multi-agent pipeline artifacts. It is a co-authored AI-human space: humans provide the request, agents generate and validate the specs and implementation notes. This is distinct from `docs/specs/` (requirements) and `docs/decisions/` (ADRs), which are maintained by humans.
+
+## How to start the pipeline
+
+Use the `/tackle` skill followed by the GitHub issue number:
+
+```
+/tackle 42
+```
+
+The orchestrator runs the full pipeline: specs → security → test cases → coding → review → tests → versioning → PR. Human approval gates apply after specs, after coding, before PR creation, and before merge.
+
+## Task folder structure
+
+All pipeline artifacts for a given task live in one folder:
+
+```
+docs/prompts/tasks/
+  issue-[id]-[slug]/
+    README.md                    ← user request (input)
+    business-specifications.md   ← specs agent output
+    security-guidelines.md       ← security agent output
+    test-cases.md                ← test-writer agent output (pass 1)
+    technical-specifications.md  ← coder agent output
+    review-results.md            ← reviewer agent output
+    test-results.md              ← test-runner agent output
+```
+
+## Agents and their prompt files
+
+| Agent         | Prompt                                  | Reads                                                                                                                                                                          | Writes                                                             |
+| ------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| Specification | `.claude/agents/agent-1-specs.md`       | `[task-folder]/README.md`                                                                                                                                                      | `[task-folder]/business-specifications.md`                         |
+| Security      | `.claude/agents/agent-5-security.md`    | `[task-folder]/business-specifications.md`                                                                                                                                     | `[task-folder]/security-guidelines.md`                             |
+| Test Writer   | `.claude/agents/agent-3-test-writer.md` | `[task-folder]/business-specifications.md`, `[task-folder]/security-guidelines.md` (pass 1); `[task-folder]/test-cases.md`, `[task-folder]/technical-specifications.md` (pass 2) | `[task-folder]/test-cases.md` (pass 1); `.spec.ts` files (pass 2) |
+| Coder         | `.claude/agents/agent-2-coder.md`       | `[task-folder]/business-specifications.md`, `[task-folder]/security-guidelines.md`, `[task-folder]/test-cases.md`                                                              | `[task-folder]/technical-specifications.md`                        |
+| Reviewer      | `.claude/agents/agent-6-reviewer.md`    | `[task-folder]/technical-specifications.md`, `[task-folder]/security-guidelines.md`, `[task-folder]/business-specifications.md`                                                | `[task-folder]/review-results.md`                                  |
+| Test Runner   | `.claude/agents/agent-3-test-runner.md` | `[task-folder]/technical-specifications.md`                                                                                                                                    | `[task-folder]/test-results.md`                                    |
+| Versioning    | `.claude/agents/agent-4-git.md`         | `[task-folder]/business-specifications.md`, `[task-folder]/test-results.md`                                                                                                    | git history                                                        |
+
+## Pipeline flow
+
+```mermaid
+flowchart TD
+    userRequest([User request]) --> versioningBranch[Versioning agent<br />Task 1-2: fetch origin + create worktree]
+    versioningBranch --> writeReadme[Orchestrator writes<br />README.md to worktree]
+    writeReadme --> specsAgent[Specs agent<br />writes business-specifications.md]
+    specsAgent -->|ADR Required → human approves| specsAgent
+    specsAgent --> approveSpecs{Human approves<br />business specs?}
+    approveSpecs -->|Rejected| stoppedAfterSpecs([Pipeline stopped])
+    approveSpecs -->|Approved| versioningCommitSpecs[Versioning agent<br />Task 3: commit business-specifications.md]
+    versioningCommitSpecs --> securityAgent[Security agent<br />writes security-guidelines.md]
+    securityAgent -->|ADR Required → human approves| securityAgent
+    securityAgent --> versioningCommitSecurity[Versioning agent<br />Task 3.5: commit security-guidelines.md]
+    versioningCommitSecurity --> testWriterPass1[Test Writer agent (pass 1)<br />writes test-cases.md]
+    testWriterPass1 --> versioningCommitTestCases[Versioning agent<br />Task 3.7: commit test-cases.md]
+    versioningCommitTestCases --> coderAgent[Coder agent<br />writes technical-specifications.md]
+    coderAgent -->|status: review specs → loop back| specsAgent
+    coderAgent --> reviewerAgent[Reviewer agent<br />runs lint + type-check + writes review-results.md]
+    reviewerAgent -->|status: changes requested → loop back| coderAgent
+    reviewerAgent -->|ADR Required → human approves| reviewerAgent
+    reviewerAgent --> approveTechnicalSpecs{Human approves<br />technical specs?}
+    approveTechnicalSpecs -->|Rejected| stoppedAfterReview([Pipeline stopped])
+    approveTechnicalSpecs -->|Approved| versioningCommitCode[Versioning agent<br />Task 4: commit source files + review-results.md]
+    versioningCommitCode --> testWriterPass2[Test Writer agent (pass 2)<br />writes .spec.ts files]
+    testWriterPass2 --> testRunnerAgent[Test Runner agent<br />runs npm test + writes test-results.md]
+    testRunnerAgent -->|status: failed → loop back| coderAgent
+    testRunnerAgent --> versioningCommitTests[Versioning agent<br />Task 5: commit test files + push branch]
+    versioningCommitTests --> approvePR{Human approves<br />PR creation?}
+    approvePR -->|Rejected| stoppedBeforePR([Pipeline stopped])
+    approvePR -->|Approved| createPR[gh pr create]
+    createPR --> approveMerge{Human approves<br />merge?}
+    approveMerge -->|Rejected| prRemainsOpen([PR remains open])
+    approveMerge -->|Approved| mergePR([gh pr merge + remove worktree])
+```


### PR DESCRIPTION
## Summary

- Sync all agent `.md` files from `french-gas-stations-scraper` (agent-0 through agent-6): slug enforcement, TDD split, exact output templates, git worktree fixes, conciseness rules
- Add `.claude/commands/fix-pipeline.md` and `tackle.md` slash command skills
- Restructure `CLAUDE.md`: split Architecture into `### Project-specific` / `### Common`, align RTK/Critical Rules/Setup sections with gas-stations-scraper
- Add `docs/prompts/README.md` with pipeline flow, agent table, and mermaid diagram (moved from CLAUDE.md)
- Also integrates RTK token killer path fix and pipeline integration from prior commits on this branch

## Test plan

- [ ] Verify `/tackle` skill resolves correctly from `.claude/commands/tackle.md`
- [ ] Verify `/fix-pipeline` skill resolves correctly from `.claude/commands/fix-pipeline.md`
- [ ] Confirm `CLAUDE.md` renders correctly and sections are in expected order
- [ ] Confirm `docs/prompts/README.md` mermaid diagram is accurate

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)