### PR TITLE
ci(agent): sync pipeline scripts and agent-4-git from gas-stations-scraper

### DIFF
--- a/.claude/agents/agent-4-git.md
+++ b/.claude/agents/agent-4-git.md
@@ -60,52 +60,50 @@ Use `rtk` for all supported git and gh commands — it compresses output and red
 
 Commands without an rtk equivalent (`git worktree`, `git fetch`, `git remote`, `git branch`, `git worktree prune`) run as normal git commands.
 
+## Pipeline Scripts
+
+Three scripts under `scripts/pipeline/` encapsulate the git operations most prone to ordering mistakes or path-discovery errors. **Always prefer these scripts over constructing raw git/gh commands.**
+
+| Script                                                         | Purpose                                                                                                                    |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `scripts/pipeline/fetch-origin.sh [bare-repo]`                 | Ensure `origin` is configured + full refspec, then fetch. Always run first (Task 1).                                       |
+| `scripts/pipeline/worktree-create.sh <type> <slug>`            | Create branch + worktree, install npm deps. Prints `Worktree: <path>`. Requires fetch-origin.sh to have run first.        |
+| `scripts/pipeline/pr-create.sh <worktree> <title> <body-file>` | Push branch, open PR against `develop`. Prints `PR: <url>`.                                                                |
+| `scripts/pipeline/pr-complete.sh <pr-url>`                     | Merge open PR (rebase + delete remote branch). Skips gracefully if already merged/closed.                                  |
+| `scripts/pipeline/worktree-cleanup.sh <worktree>`              | Remove worktree directory, prune stale entries, delete local branch.                                                       |
+| `scripts/pipeline/refresh-develop.sh`                          | Fetch origin and fast-forward the `develop` worktree. Closes the pipeline cycle.                                           |
+
+Call them with `bash scripts/pipeline/<script>.sh` from the `develop/` worktree (the scripts resolve the bare repo root automatically).
+
 ## Tasks
 
 ### Task 1: Make Sure Local Repository Is Up-to-date
 
-The session runs from the `develop/` worktree. The bare repo root is `..` relative to the CWD.
-
-First verify the bare repo has `origin` configured:
+**Always run this first — never skip it.**
 
 ```bash
-git -C .. remote -v
+bash scripts/pipeline/fetch-origin.sh
 ```
 
-If `origin` is missing, add it before fetching:
-
-```bash
-git -C .. remote add origin https://github.com/<owner>/<repo>.git
-```
-
-Then fetch to update all remote refs. The bare repo has no working tree to pull into — do **not** use `git pull`.
-
-First ensure the fetch refspec is configured (bare repos often lack it, causing `fetch` to update only `FETCH_HEAD` and leaving `refs/remotes/origin/*` stale):
-
-```bash
-git -C .. config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-git -C .. fetch origin
-```
+Ensures `origin` is configured (adds it if missing, inferring the URL from `develop/`), sets the full fetch refspec, and fetches all remote refs.
 
 ### Task 2: Create new branch and worktree
 
-The orchestrator passes `Type: <type>` and `Slug: <slug>` directly — use these values. Do NOT read any file or create any directory to determine them.
+The orchestrator passes `Type: <type>` and `Slug: <slug>` directly — use these values.
 
-Run from the `develop/` worktree (bare repo root is `..`):
-
-```bash
-git -C .. worktree add <type>_<slug> -b <type>/<slug> origin/develop
-```
-
-The path `<type>_<slug>` is relative to the bare repo root (the `-C ..` directory), so the worktree lands at `<bare-repo>/<type>_<slug>` — i.e. a sibling of `develop/`. Do NOT prefix with `../` (that would place it one level above the bare repo).
-
-Then install dependencies inside the new worktree so subsequent agents can run lint, type-check, and tests:
+**Requires Task 1 to have completed successfully.**
 
 ```bash
-cd <type>_<slug> && npm install
+bash scripts/pipeline/worktree-create.sh <type> <slug>
 ```
 
-Resolve the absolute path of the new worktree and report it back to the orchestrator as `Worktree: <absolute-path>` so every subsequent agent can use it.
+Creates `<bare-repo>/<type>_<slug>` on branch `<type>/<slug>` from `origin/develop` and installs npm dependencies. Prints:
+
+```
+Worktree: <absolute-path>
+```
+
+Report that path back to the orchestrator as `Worktree: <absolute-path>`.
 
 ### Task 3: Commit specs output
 
@@ -156,50 +154,37 @@ If the last line is `status: passed`:
 
 ### Task 6: Create pull request
 
-Run from the worktree root:
+- Derive the PR title from `[task-folder]/business-specifications.md` (short imperative summary, ≤70 chars).
+- Write the PR body to a temporary file (e.g. `/tmp/pr-body.md`). The body must include: a summary of what changed and why, a test plan checklist, and `Closes #<issue-id>`.
+- Target branch is always `develop` — never `main`.
 
 ```bash
-gh pr create --base develop --title "<title>" --body "<body>"
+# Write the body to a temp file first, then call the script:
+cat > /tmp/pr-body.md << 'EOF'
+<body content here>
+EOF
+
+bash scripts/pipeline/pr-create.sh <worktree> "<title>" /tmp/pr-body.md
 ```
 
-- Derive the PR title from `[task-folder]/business-specifications.md` (short imperative summary, ≤70 chars).
-- The PR body must include: a summary of what changed and why, a test plan checklist, and a reference to the issue (`Closes #<issue-id>`).
-- Target branch is always `develop` — never `main`.
-- Report the PR URL back to the orchestrator.
+The script pushes the branch and opens the PR. It prints `PR: <url>` — report that URL back to the orchestrator.
 
 ### Task 7: Merge pull request
 
-Must run from the bare repo root (not from inside any worktree) to avoid `gh` attempting a local `git switch develop` after merging, which fails because `develop` is already checked out in its own worktree.
-
 ```bash
-cd .. && gh pr merge <pr-url> --rebase --delete-branch
+bash scripts/pipeline/pr-complete.sh <pr-url>
 ```
 
-- Always rebase-merge to keep `develop` history linear (the repository does not allow squash or merge commits).
-- `--delete-branch` removes the remote branch automatically.
+Merges the PR with rebase and deletes the remote branch. Skips gracefully if the PR was already merged or closed by the user on GitHub.
 
-### Task 8: Remove worktree (post-merge cleanup)
-
-Run from the bare repo root (`..` relative to the `develop/` worktree):
+### Task 8: Remove worktree and refresh develop
 
 ```bash
-git -C .. fetch origin
-git -C .. worktree remove --force <type>_<slug>
-git -C .. worktree prune
-git -C .. branch -D <type>/<slug>
+bash scripts/pipeline/worktree-cleanup.sh <worktree>
+bash scripts/pipeline/refresh-develop.sh
 ```
 
-Notes:
-- Run `git worktree remove --force` **before** `git worktree prune`. Prune deregisters stale entries first; if the worktree directory still exists but is deregistered, a subsequent `remove` will fail with a permission error.
-- `--force` handles Windows file-lock edge cases where git would otherwise refuse to delete the directory.
-- If the worktree directory still exists on disk after `git worktree remove --force` (e.g. because git already deregistered it in a prior run), delete it manually: `rm -rf <absolute-worktree-path>`.
-- Use `-D` (force) instead of `-d` on `git branch` because GitHub rebase-merges do not create a merge commit, so git never considers the local branch "fully merged".
-
-Then pull latest into `develop/` to ensure it reflects the merged commit:
-
-```bash
-git pull origin develop
-```
+`worktree-cleanup.sh` removes the worktree directory, prunes stale git entries, and deletes the local branch. `refresh-develop.sh` fetches origin and fast-forwards `develop`. Both scripts are safe to re-run if a prior attempt was partial.
 
 ## Shell Command Retry Limit
 

--- a/scripts/pipeline/fetch-origin.sh
+++ b/scripts/pipeline/fetch-origin.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/pipeline/fetch-origin.sh
+#
+# Usage: bash scripts/pipeline/fetch-origin.sh [bare-repo-path]
+#
+# Ensures the bare repo has `origin` configured with the correct fetch
+# refspec, then fetches all remote refs.
+#
+# <bare-repo-path> defaults to the parent of the worktree that contains
+# this script (i.e. `..` relative to `develop/`), which is correct for
+# all standard pipeline worktrees.
+#
+# Called automatically by worktree-create.sh. Run standalone when only
+# a fetch is needed (e.g. Task 1 without Task 2).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_BARE="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BARE_REPO="${1:-$DEFAULT_BARE}"
+
+# Ensure origin remote exists
+if ! git -C "$BARE_REPO" remote get-url origin &>/dev/null; then
+  REMOTE_URL="$(cd "$BARE_REPO/develop" && git remote get-url origin 2>/dev/null || true)"
+  if [ -z "$REMOTE_URL" ]; then
+    echo "ERROR: origin remote not found in bare repo and could not be inferred." >&2
+    echo "Run: git -C \"$BARE_REPO\" remote add origin <url>" >&2
+    exit 1
+  fi
+  git -C "$BARE_REPO" remote add origin "$REMOTE_URL"
+fi
+
+# Ensure full refspec so remote-tracking refs stay current
+git -C "$BARE_REPO" config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+git -C "$BARE_REPO" fetch origin
+
+echo "==> origin fetched (bare repo: $BARE_REPO)"

--- a/scripts/pipeline/pr-complete.sh
+++ b/scripts/pipeline/pr-complete.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# scripts/pipeline/pr-complete.sh
+#
+# Usage: bash scripts/pipeline/pr-complete.sh <pr-url>
+#
+# Merges an open PR into develop (rebase strategy) and deletes the remote
+# branch. Skips gracefully if the PR is already merged or closed.
+#
+# Run from any pipeline worktree. Follow with:
+#   worktree-cleanup.sh <worktree-path>
+#   refresh-develop.sh
+
+set -euo pipefail
+
+PR_URL="${1:?Usage: pr-complete.sh <pr-url>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+echo "==> Checking PR state..."
+PR_STATE="$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")"
+
+if [ "$PR_STATE" = "MERGED" ]; then
+  echo "    PR already merged — nothing to do."
+  exit 0
+elif [ "$PR_STATE" = "CLOSED" ]; then
+  echo "    PR is closed (not merged) — nothing to do."
+  exit 0
+fi
+
+echo "==> Merging PR (rebase)..."
+# Run from bare repo root so `gh` does not attempt a local `git switch develop`
+# (which would fail because develop is already checked out in its own worktree).
+(cd "$BARE_REPO" && gh pr merge "$PR_URL" --rebase --delete-branch)
+
+echo "==> PR merged."

--- a/scripts/pipeline/pr-create.sh
+++ b/scripts/pipeline/pr-create.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/pipeline/pr-create.sh
+#
+# Usage: bash scripts/pipeline/pr-create.sh <worktree-path> <title> <body-file>
+#
+# Pushes the current branch and opens a PR against `develop`.
+# Prints the PR URL as "PR: <url>".
+#
+# Arguments:
+#   <worktree-path>  Absolute path to the feature worktree.
+#   <title>          PR title (≤70 chars, imperative mood).
+#   <body-file>      Path to a file containing the full PR body (markdown).
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+TITLE="${2:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+BODY_FILE="${3:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+
+BRANCH="$(git -C "$WORKTREE" branch --show-current)"
+
+echo "==> Pushing branch '${BRANCH}' to origin..."
+git -C "$WORKTREE" push origin "$BRANCH"
+
+echo "==> Creating PR..."
+PR_URL="$(cd "$WORKTREE" && gh pr create \
+  --base develop \
+  --title "$TITLE" \
+  --body-file "$BODY_FILE")"
+
+echo "PR: ${PR_URL}"

--- a/scripts/pipeline/refresh-develop.sh
+++ b/scripts/pipeline/refresh-develop.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/pipeline/refresh-develop.sh
+#
+# Usage: bash scripts/pipeline/refresh-develop.sh
+#
+# Fetches all remote refs and fast-forwards the develop worktree to
+# origin/develop. Call this at the end of every pipeline cycle to ensure
+# the next pipeline starts from an up-to-date base.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEVELOP="${BARE_REPO}/develop"
+
+echo "==> Fetching origin..."
+git -C "$BARE_REPO" fetch origin
+
+echo "==> Updating develop..."
+git -C "$DEVELOP" pull origin develop
+
+echo "==> develop is up to date."

--- a/scripts/pipeline/worktree-cleanup.sh
+++ b/scripts/pipeline/worktree-cleanup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/pipeline/worktree-cleanup.sh
+#
+# Usage: bash scripts/pipeline/worktree-cleanup.sh <worktree-path>
+#
+# Removes a pipeline worktree directory, prunes stale git entries, and
+# deletes the local branch. Safe to re-run if a prior attempt was partial.
+#
+# Run after pr-complete.sh (or after a manual GitHub merge/close).
+# Follow with refresh-develop.sh to fast-forward the develop worktree.
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: worktree-cleanup.sh <worktree-path>}"
+
+BARE_REPO="$(cd "$WORKTREE/.." && pwd)"
+WT_NAME="$(basename "$WORKTREE")"
+
+# Read branch name before the worktree is removed
+BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
+
+echo "==> Removing worktree '${WT_NAME}'..."
+git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true
+# If git already deregistered the entry, the directory may still exist on disk
+if [ -d "$WORKTREE" ]; then
+  rm -rf "$WORKTREE"
+fi
+
+echo "==> Pruning stale worktree entries..."
+git -C "$BARE_REPO" worktree prune
+
+if [ -n "$BRANCH" ]; then
+  echo "==> Deleting local branch '${BRANCH}'..."
+  # Use -D (force) because GitHub rebase-merge does not create a merge commit,
+  # so git never considers the local branch "fully merged".
+  git -C "$BARE_REPO" branch -D "$BRANCH" 2>/dev/null || true
+fi
+
+echo "==> Worktree '${WT_NAME}' cleaned up."

--- a/scripts/pipeline/worktree-create.sh
+++ b/scripts/pipeline/worktree-create.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/pipeline/worktree-create.sh
+#
+# Usage: bash scripts/pipeline/worktree-create.sh <type> <slug>
+#
+# Creates a git worktree for a new feature/fix branch, installs npm deps,
+# and prints the absolute worktree path as "Worktree: <path>".
+#
+# Works when called from any worktree (develop/, feat_*/,  ci_*/) because
+# the bare repo is always the parent directory of whichever worktree holds
+# this script.
+#
+# Prerequisites: run fetch-origin.sh before this script.
+
+set -euo pipefail
+
+TYPE="${1:?Usage: worktree-create.sh <type> <slug>}"
+SLUG="${2:?Usage: worktree-create.sh <type> <slug>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# scripts/pipeline is 2 levels below the worktree root, which is 1 level
+# below the bare repo: <bare-repo>/<worktree>/scripts/pipeline
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+WT_NAME="${TYPE}_${SLUG}"
+BRANCH="${TYPE}/${SLUG}"
+WT_PATH="${BARE_REPO}/${WT_NAME}"
+
+echo "==> Creating worktree '${WT_NAME}' on branch '${BRANCH}'..."
+git -C "$BARE_REPO" worktree add "$WT_NAME" -b "$BRANCH" origin/develop
+
+echo "==> Installing npm dependencies in ${WT_PATH}..."
+(cd "$WT_PATH" && npm install --silent)
+
+echo "Worktree: ${WT_PATH}"


### PR DESCRIPTION
## Summary

- Add `scripts/pipeline/` directory with 6 bash scripts (fetch-origin, worktree-create, pr-create, pr-complete, worktree-cleanup, refresh-develop) synced from the french-gas-stations-scraper repo
- Update `agent-4-git.md` Tasks 1, 2, 6, 7, 8 to delegate to these scripts instead of constructing raw git/gh commands inline
- Add a "Pipeline Scripts" reference table to the agent so it knows what each script does

## Test plan

- [ ] Trigger a pipeline run and verify Task 1 calls `fetch-origin.sh` successfully
- [ ] Verify Task 2 calls `worktree-create.sh` and prints `Worktree: <path>`
- [ ] Verify Task 6 uses `pr-create.sh` with a body file
- [ ] Verify Task 7 uses `pr-complete.sh` (graceful skip if already merged)
- [ ] Verify Task 8 calls `worktree-cleanup.sh` then `refresh-develop.sh`

Closes #102