### PR TITLE
fix(pipeline): derive bare repo from git, support sibling worktrees

### DIFF
--- a/.claude/commands/jli-code.md
+++ b/.claude/commands/jli-code.md
@@ -1,12 +1,13 @@
 Implement the feature. Task folder: $ARGUMENTS
 
-`$ARGUMENTS` must be the absolute task-folder path. If it is empty, stop and reply:
+`$ARGUMENTS` is the task folder, given as a `@`-mention relative to the worktree root you
+opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
 
-> Usage: `/jli-code <task-folder>` — I need the absolute task-folder path.
+> Usage: `/jli-code @<task-folder>` — open the feature worktree (`code <worktree>`) first,
+> then pass the task folder relative to it.
 
-Derive `[worktree]` from the argument (the substring before `/docs/prompts/tasks/`).
-All file paths are relative to `[worktree]` — never read or write outside it. If you run a
-shell command, `cd [worktree]` first; never run from the bare repo root.
+Run from the worktree root (your current directory). All file paths are relative to it —
+never read or write outside this worktree.
 
 ## What this command does
 
@@ -81,7 +82,7 @@ to `/jli-test-run` and `/jli-review`.
 ## RTK token optimization
 
 Prefer the Read/Glob/Grep tools. For shell, prefer `rtk ls`, `rtk read <file>`,
-`rtk grep <pattern>` (use absolute paths).
+`rtk grep <pattern>` (paths relative to the worktree root).
 
 ## Shell command retry limit
 
@@ -91,11 +92,11 @@ the full error output to the user.
 ## Next
 
 - If the file ends `status: review specs`:
-  > The specs need review. Run `/jli-spec [task-folder]` to revise them, re-commit, then
-  > return to `/jli-code [task-folder]`.
+  > The specs need review. Run `/jli-spec @<task-folder>` to revise them, re-commit, then
+  > return to `/jli-code @<task-folder>`.
 - If the file contains `### ADR Required`:
   > ⚠ This implementation requires a new ADR. Approve it (add under `docs/decisions/`, update
-  > the index) before committing, then run `/jli-git-commit [task-folder]`.
+  > the index) before committing, then run `/jli-git-commit @<task-folder>`.
 - Otherwise:
-  > Implementation ready. Review `[task-folder]/technical-specifications.md`, run
-  > `/jli-git-commit [task-folder]`, then (optionally `/clear` and) `/jli-review [task-folder]`.
+  > Implementation ready. Review `technical-specifications.md` in the task folder, run
+  > `/jli-git-commit @<task-folder>`, then (optionally `/clear` and) `/jli-review @<task-folder>`.

--- a/.claude/commands/jli-git-cleanup.md
+++ b/.claude/commands/jli-git-cleanup.md
@@ -1,0 +1,47 @@
+Remove a merged feature worktree and refresh develop. Worktree: $ARGUMENTS
+
+`$ARGUMENTS` is the feature worktree to remove — either its folder name
+(e.g. `<repo-name>_<type>-<slug>`) or an absolute path. If it is empty, list the candidates
+and ask which to remove:
+
+```bash
+git worktree list
+```
+
+> Usage: `/jli-git-cleanup <worktree-folder-name>` — run this from the `develop` worktree,
+> after the PR has merged.
+
+## Run location
+
+Run this from the **develop worktree**, never from inside the worktree being removed (you
+cannot delete the directory you are standing in). If your current directory is the feature
+worktree, stop and tell the user to `code [develop-worktree]` and run the command there.
+
+## What this command does
+
+The PR for this feature is already merged (by `/jli-git-ship` or manually on GitHub). This
+removes the local worktree, prunes stale git entries, deletes the local branch, and
+fast-forwards `develop`.
+
+```bash
+bash scripts/pipeline/worktree-cleanup.sh "$ARGUMENTS"
+bash scripts/pipeline/refresh-develop.sh
+```
+
+`worktree-cleanup.sh` accepts either a bare folder name (resolved against the parent of the
+bare repo) or an absolute path. It removes the worktree, prunes, and force-deletes the local
+branch (GitHub rebase/squash-merge leaves the local branch looking "unmerged"). Both scripts
+are safe to re-run if a prior attempt was partial.
+
+If `worktree-cleanup.sh` reports the worktree is still in use, confirm you are not running
+from inside it, then re-run.
+
+## Shell command retry limit
+
+Do not run more than 3 failing shell commands in total. After 3 failures, stop and report
+the full error output to the user.
+
+## Next
+
+> Feature shipped and cleaned up: worktree removed, local branch deleted, `develop` updated.
+> The chain is complete.

--- a/.claude/commands/jli-git-commit.md
+++ b/.claude/commands/jli-git-commit.md
@@ -1,13 +1,14 @@
 Commit the current phase's artifacts. Task folder: $ARGUMENTS
 
-`$ARGUMENTS` must be the absolute task-folder path. If it is empty, stop and reply:
+`$ARGUMENTS` is the task folder, given as a `@`-mention relative to the worktree root you
+opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
 
-> Usage: `/jli-git-commit <task-folder>` — I need the absolute task-folder path.
+> Usage: `/jli-git-commit @<task-folder>` — open the feature worktree (`code <worktree>`)
+> first, then pass the task folder relative to it.
 
-Derive `[worktree]` from the argument (the substring before `/docs/prompts/tasks/`). Always
-`cd [worktree]` before any git command — never commit from the bare repo root, and never
-commit directly to `develop` or `main` (you are on the feature branch the worktree created).
-Parse the issue `[id]` from the task-folder name (`issue-<id>-<slug>`).
+Run all git commands from the worktree root (your current directory) — never from the bare
+repo root, and never commit directly to `develop` or `main` (you are on the feature branch
+the worktree created). Parse the issue `[id]` from the task-folder name (`issue-<id>-<slug>`).
 
 ## What this command does
 
@@ -15,7 +16,7 @@ This is the commit step run between phases. Inspect what changed, then create on
 conventional commit with the matching type. Use `rtk` for all git commands.
 
 ```bash
-cd [worktree] && rtk git status
+rtk git status
 ```
 
 ## Choosing the commit type from what changed
@@ -39,8 +40,8 @@ General conventional-commit rules: subject in imperative mood, lowercase, no per
 Stage only the files belonging to the current phase, then:
 
 ```bash
-cd [worktree] && rtk git add <files>
-cd [worktree] && rtk git commit -m "<message>"
+rtk git add <files>
+rtk git commit -m "<message>"
 ```
 
 Do NOT push here — `/jli-git-ship` pushes.
@@ -49,7 +50,7 @@ Do NOT push here — `/jli-git-ship` pushes.
 
 If you discover a bug or code issue while committing, do NOT fix it here. Stop, describe the
 bug, the file(s) affected, and the root cause, and tell the user to route it through
-`/jli-code [task-folder]`.
+`/jli-code @<task-folder>`.
 
 ## Shell command retry limit
 
@@ -60,13 +61,13 @@ the full error output to the user.
 
 Report the commit. Then point the user to the next phase based on what was just committed:
 
-- after specs → `/jli-security [task-folder]`
-- after security → `/jli-test-write [task-folder]` (pass 1)
-- after test-cases → `/jli-code [task-folder]`
-- after code/review (approved) → `/jli-test-write [task-folder]` (pass 2)
-- after review (changes requested) → `/jli-code [task-folder]`
-- after `*.spec.ts` → `/jli-test-run [task-folder]`
-- after test-results (passed) → `/jli-git-ship [task-folder]`
-- after test-results (failed) → `/jli-code [task-folder]`
+- after specs → `/jli-security @<task-folder>`
+- after security → `/jli-test-write @<task-folder>` (pass 1)
+- after test-cases → `/jli-code @<task-folder>`
+- after code/review (approved) → `/jli-test-write @<task-folder>` (pass 2)
+- after review (changes requested) → `/jli-code @<task-folder>`
+- after `*.spec.ts` → `/jli-test-run @<task-folder>`
+- after test-results (passed) → `/jli-git-ship @<task-folder>`
+- after test-results (failed) → `/jli-code @<task-folder>`
 
 > Committed. You may run `/clear` before the next command.

--- a/.claude/commands/jli-git-setup.md
+++ b/.claude/commands/jli-git-setup.md
@@ -32,13 +32,14 @@ bash scripts/pipeline/fetch-origin.sh
 bash scripts/pipeline/worktree-create.sh <type> <slug>
 ```
 
-`worktree-create.sh` creates `<bare-repo>/<type>_<slug>` on branch `<type>/<slug>` from
-`origin/develop`, installs npm deps, and prints `Worktree: <absolute-path>`. Capture that
-absolute path as `[worktree]`.
+`worktree-create.sh` creates the worktree folder `<repo-name>_<type>-<slug>` (a sibling of
+the bare repo) on branch `<type>/<slug>` from `origin/develop`, installs npm deps, and prints
+`Worktree: <absolute-path>`. Capture that absolute path as `[worktree]`.
 
 ### Step 3 — Create the task folder and README
 
 - `task-folder` = `[worktree]/docs/prompts/tasks/issue-<id>-<slug>/`
+- The relative form (used by every later command) is `docs/prompts/tasks/issue-<id>-<slug>`.
 - Write `[task-folder]/README.md` containing:
   - A first line: `Worktree: [worktree]` (so the path is recorded for reference).
   - The issue title and the full issue body fetched in Step 1, plus any extra notes the
@@ -64,10 +65,20 @@ the full error output to the user.
 
 ## Next
 
-Report the absolute task-folder path to the user, then show:
+Report the absolute worktree path and the relative task-folder path, then show:
 
 > Worktree and task folder ready.
-> Task folder: `[task-folder]`
+> Worktree: `[worktree]`
+> Task folder (relative): `docs/prompts/tasks/issue-<id>-<slug>`
 >
-> Next: run `/clear` (optional), then `/jli-spec [task-folder]` to write the business
-> specifications. Pass that exact task-folder path to every command in the chain.
+> Next: open the worktree in its own editor window so the rest of the chain runs in its
+> context:
+>
+> ```
+> code [worktree]
+> ```
+>
+> Then, from that window, run `/jli-spec @docs/prompts/tasks/issue-<id>-<slug>`. Every later
+> command takes the task folder as a `@`-mention relative to the worktree root — you never
+> need the absolute path again. The final cleanup command is the exception: it runs back in
+> this `develop` window.

--- a/.claude/commands/jli-git-ship.md
+++ b/.claude/commands/jli-git-ship.md
@@ -1,18 +1,20 @@
-Push, open the PR, merge, and clean up. Task folder: $ARGUMENTS
+Push, open the PR, and merge. Task folder: $ARGUMENTS
 
-`$ARGUMENTS` must be the absolute task-folder path. If it is empty, stop and reply:
+`$ARGUMENTS` is the task folder, given as a `@`-mention relative to the worktree root you
+opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
 
-> Usage: `/jli-git-ship <task-folder>` — I need the absolute task-folder path.
+> Usage: `/jli-git-ship @<task-folder>` — run this from the feature worktree
+> (`code <worktree>`), passing the task folder relative to it.
 
-Derive `[worktree]` from the argument (the substring before `/docs/prompts/tasks/`). Parse
-the issue `[id]` from the task-folder name. Use the pipeline scripts; they resolve the bare
-repo root automatically. This command is outward-facing and irreversible — honour the two
-approval gates below.
+Run from the feature worktree root (your current directory). Parse the issue `[id]` from the
+task-folder name. The pipeline scripts resolve the bare repo automatically. This command is
+outward-facing and irreversible — honour the two approval gates below. It does NOT remove the
+worktree (you are standing in it); cleanup is a separate command run from `develop`.
 
 ## Step 1 — Push and open the PR
 
-Confirm `[task-folder]/test-results.md` ends with `status: passed`. If not, stop and tell
-the user to finish `/jli-test-run [task-folder]` first.
+Confirm `test-results.md` in the task folder ends with `status: passed`. If not, stop and
+tell the user to finish `/jli-test-run @<task-folder>` first.
 
 Derive the PR title from `business-specifications.md` (short imperative summary, ≤70 chars).
 Write the PR body to a temp file: a summary of what changed and why, a test-plan checklist,
@@ -23,7 +25,7 @@ cat > /tmp/pr-body.md << 'EOF'
 <body content here>
 EOF
 
-bash scripts/pipeline/pr-create.sh [worktree] "<title>" /tmp/pr-body.md
+bash scripts/pipeline/pr-create.sh "$(pwd)" "<title>" /tmp/pr-body.md
 ```
 
 `pr-create.sh` pushes the branch and opens the PR against `develop`, printing `PR: <url>`.
@@ -42,17 +44,6 @@ bash scripts/pipeline/pr-complete.sh <pr-url>
 
 Merges with rebase and deletes the remote branch. Skips gracefully if already merged/closed.
 
-## Step 3 — Clean up
-
-```bash
-bash scripts/pipeline/worktree-cleanup.sh [worktree]
-bash scripts/pipeline/refresh-develop.sh
-```
-
-`worktree-cleanup.sh` removes the worktree, prunes stale entries, and deletes the local
-branch. `refresh-develop.sh` fetches origin and fast-forwards `develop`. Both are safe to
-re-run.
-
 ## Shell command retry limit
 
 Do not run more than 3 failing shell commands in total. After 3 failures, stop and report
@@ -60,4 +51,12 @@ the full error output to the user.
 
 ## Next
 
-> Feature shipped: PR merged, worktree cleaned up, `develop` updated. The chain is complete.
+> PR merged. Last step — clean up the worktree from the `develop` window (you can't remove
+> the worktree you're standing in):
+>
+> ```
+> code [develop-worktree]
+> ```
+>
+> Then run `/jli-git-cleanup <worktree-folder-name>` there (the folder name is the last
+> segment of this worktree's path, e.g. `<repo-name>_<type>-<slug>`).

--- a/.claude/commands/jli-review.md
+++ b/.claude/commands/jli-review.md
@@ -1,11 +1,13 @@
 Review the implementation. Task folder: $ARGUMENTS
 
-`$ARGUMENTS` must be the absolute task-folder path. If it is empty, stop and reply:
+`$ARGUMENTS` is the task folder, given as a `@`-mention relative to the worktree root you
+opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
 
-> Usage: `/jli-review <task-folder>` — I need the absolute task-folder path.
+> Usage: `/jli-review @<task-folder>` — open the feature worktree (`code <worktree>`) first,
+> then pass the task folder relative to it.
 
-Derive `[worktree]` from the argument (the substring before `/docs/prompts/tasks/`). The
-bare repo root has no `node_modules` — always `cd [worktree]` before any shell command.
+Run from the worktree root (your current directory) — that is where `node_modules` lives and
+where the shell commands below must run.
 
 ## What this command does
 
@@ -17,8 +19,8 @@ Run exactly these two commands from the worktree (they are guaranteed to exist i
 `package.json`; do not inspect `package.json` first). Include their output in your findings:
 
 ```bash
-cd [worktree] && rtk lint           # eslint . --fix, grouped, token-optimized
-cd [worktree] && npm run type-check # vue-tsc --build (no rtk equivalent)
+rtk lint           # eslint . --fix, grouped, token-optimized
+npm run type-check # vue-tsc --build (no rtk equivalent)
 ```
 
 Do NOT run `npm run test` — that is `/jli-test-run`'s job.
@@ -65,9 +67,9 @@ If you hit the 3-failing-shell-command limit, record the error output and end th
 ## Next
 
 - If `status: changes requested`:
-  > Review found issues (see `[task-folder]/review-results.md`). Run `/jli-git-commit
-  > [task-folder]` to record the review, then `/jli-code [task-folder]` to address the
-  > findings, then `/jli-review [task-folder]` again.
+  > Review found issues (see `review-results.md` in the task folder). Run
+  > `/jli-git-commit @<task-folder>` to record the review, then `/jli-code @<task-folder>` to
+  > address the findings, then `/jli-review @<task-folder>` again.
 - If `status: approved`:
-  > Review approved. Run `/jli-git-commit [task-folder]`, then (optionally `/clear` and)
-  > `/jli-test-write [task-folder]` for pass 2 (the `.spec.ts` files).
+  > Review approved. Run `/jli-git-commit @<task-folder>`, then (optionally `/clear` and)
+  > `/jli-test-write @<task-folder>` for pass 2 (the `.spec.ts` files).

--- a/.claude/commands/jli-security.md
+++ b/.claude/commands/jli-security.md
@@ -1,11 +1,13 @@
 Write security guidelines for a feature. Task folder: $ARGUMENTS
 
-`$ARGUMENTS` must be the absolute path to the task folder. If it is empty, stop and reply:
+`$ARGUMENTS` is the task folder, given as a `@`-mention relative to the worktree root you
+opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
 
-> Usage: `/jli-security <task-folder>` — I need the absolute task-folder path.
+> Usage: `/jli-security @<task-folder>` — open the feature worktree (`code <worktree>`) first,
+> then pass the task folder relative to it.
 
-Derive `[worktree]` from the argument (the substring before `/docs/prompts/tasks/`).
-Read and write only inside `[worktree]`.
+Run from the worktree root (your current directory). All paths below are relative to it; read
+and write only inside this worktree.
 
 ## What this command does
 
@@ -55,8 +57,8 @@ the full error output to the user.
 
 ## Next
 
-> Security guidelines ready. Review `[task-folder]/security-guidelines.md`, then run
-> `/jli-git-commit [task-folder]`, then (optionally `/clear` and)
-> `/jli-test-write [task-folder]` to write the plain-language test cases (pass 1).
+> Security guidelines ready. Review `security-guidelines.md` in the task folder, then run
+> `/jli-git-commit @<task-folder>`, then (optionally `/clear` and)
+> `/jli-test-write @<task-folder>` to write the plain-language test cases (pass 1).
 
 If the file contains `### ADR Required`, warn the user to approve the ADR before continuing.

--- a/.claude/commands/jli-spec.md
+++ b/.claude/commands/jli-spec.md
@@ -1,14 +1,13 @@
 Write the business specifications for a feature. Task folder: $ARGUMENTS
 
-`$ARGUMENTS` must be the absolute path to the task folder created by `/jli-git-setup`
-(e.g. `…/<type>_<slug>/docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
+`$ARGUMENTS` is the task folder, given as a `@`-mention relative to the worktree root you
+opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
 
-> Usage: `/jli-spec <task-folder>` — I need the absolute task-folder path printed by
-> `/jli-git-setup`.
+> Usage: `/jli-spec @<task-folder>` — open the feature worktree (`code <worktree>`) first,
+> then pass the task folder relative to it.
 
-Derive the worktree root `[worktree]` from the argument: it is the substring before
-`/docs/prompts/tasks/`. Resolve every path below under `[worktree]`. This command reads and
-writes only inside `[worktree]`.
+Run from the worktree root (your current directory). All paths below are relative to it; read
+and write only inside this worktree.
 
 ## What this command does
 
@@ -69,7 +68,7 @@ Show the user a short summary of the spec, then:
 - If the file contains `### ADR Required`:
   > ⚠ This spec requires a new ADR. Review and approve the ADR before continuing. Once
   > approved (add it under `docs/decisions/` and update `docs/decisions/README.md`), run
-  > `/jli-git-commit [task-folder]`.
+  > `/jli-git-commit @<task-folder>`.
 - Otherwise:
-  > Spec ready. Review `[task-folder]/business-specifications.md`, then run
-  > `/jli-git-commit [task-folder]`, then (optionally `/clear` and) `/jli-security [task-folder]`.
+  > Spec ready. Review `business-specifications.md` in the task folder, then run
+  > `/jli-git-commit @<task-folder>`, then (optionally `/clear` and) `/jli-security @<task-folder>`.

--- a/.claude/commands/jli-test-run.md
+++ b/.claude/commands/jli-test-run.md
@@ -1,18 +1,19 @@
 Run the test suite. Task folder: $ARGUMENTS
 
-`$ARGUMENTS` must be the absolute task-folder path. If it is empty, stop and reply:
+`$ARGUMENTS` is the task folder, given as a `@`-mention relative to the worktree root you
+opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`). If it is empty, stop and reply:
 
-> Usage: `/jli-test-run <task-folder>` — I need the absolute task-folder path.
+> Usage: `/jli-test-run @<task-folder>` — open the feature worktree (`code <worktree>`) first,
+> then pass the task folder relative to it.
 
-Derive `[worktree]` from the argument (the substring before `/docs/prompts/tasks/`). The
-bare repo root has no `node_modules` — always `cd [worktree]` first.
+Run from the worktree root (your current directory) — that is where `node_modules` lives.
 
 ## What this command does
 
 Run Vitest in non-watch mode (failures only — saves tokens) from the worktree:
 
 ```bash
-cd [worktree] && rtk vitest run
+rtk vitest run
 ```
 
 ## Output contract
@@ -62,9 +63,9 @@ full error output in `test-results.md`, and end the file with `status: failed`.
 ## Next
 
 - If `status: failed`:
-  > Tests failed (see `[task-folder]/test-results.md`). Run `/jli-git-commit [task-folder]`
-  > to record the results, then `/jli-code [task-folder]` to fix, then re-run
-  > `/jli-review [task-folder]` and `/jli-test-run [task-folder]`.
+  > Tests failed (see `test-results.md` in the task folder). Run `/jli-git-commit @<task-folder>`
+  > to record the results, then `/jli-code @<task-folder>` to fix, then re-run
+  > `/jli-review @<task-folder>` and `/jli-test-run @<task-folder>`.
 - If `status: passed`:
-  > All tests pass. Run `/jli-git-commit [task-folder]`, then `/jli-git-ship [task-folder]`
-  > to push, open the PR, and (after approval) merge and clean up.
+  > All tests pass. Run `/jli-git-commit @<task-folder>`, then `/jli-git-ship @<task-folder>`
+  > to push, open the PR, and merge after approval.

--- a/.claude/commands/jli-test-write.md
+++ b/.claude/commands/jli-test-write.md
@@ -1,12 +1,14 @@
 Write test artifacts for a feature. Task folder (and optional pass): $ARGUMENTS
 
-`$ARGUMENTS` must start with the absolute task-folder path, optionally followed by `1` or
+`$ARGUMENTS` starts with the task folder, given as a `@`-mention relative to the worktree
+root you opened (e.g. `@docs/prompts/tasks/issue-<id>-<slug>`), optionally followed by `1` or
 `2` to force the pass. If it is empty, stop and reply:
 
-> Usage: `/jli-test-write <task-folder> [1|2]` — I need the absolute task-folder path.
+> Usage: `/jli-test-write @<task-folder> [1|2]` — open the feature worktree
+> (`code <worktree>`) first, then pass the task folder relative to it.
 
-Derive `[worktree]` from the argument (the substring before `/docs/prompts/tasks/`).
-Read and write only inside `[worktree]`.
+Run from the worktree root (your current directory). All paths below are relative to it; read
+and write only inside this worktree.
 
 ## Pass selection
 
@@ -65,8 +67,8 @@ the full error output to the user.
 ## Next
 
 - After **pass 1**:
-  > Test cases ready. Run `/jli-git-commit [task-folder]`, then (optionally `/clear` and)
-  > `/jli-code [task-folder]` to implement.
+  > Test cases ready. Run `/jli-git-commit @<task-folder>`, then (optionally `/clear` and)
+  > `/jli-code @<task-folder>` to implement.
 - After **pass 2**:
-  > Test files written. Run `/jli-git-commit [task-folder]`, then (optionally `/clear` and)
-  > `/jli-test-run [task-folder]` to run the suite.
+  > Test files written. Run `/jli-git-commit @<task-folder>`, then (optionally `/clear` and)
+  > `/jli-test-run @<task-folder>` to run the suite.

--- a/.claude/commands/jli-tweak-command-chain.md
+++ b/.claude/commands/jli-tweak-command-chain.md
@@ -46,10 +46,13 @@ command must still hold ALL of these invariants:
 1. **Self-contained** — no reference to any `agent-*.md` file and **no orchestrator
    vocabulary** ("orchestrator", "the orchestrator passes", "notify/report to the
    orchestrator"). The chain and the deprecated pipeline must share no text.
-2. **Argument guard** — opens by requiring its argument and printing a usage line when empty
-   (task-folder path for every command except `jli-git-setup`, which takes an issue number).
-3. **Worktree derivation** — phase/commit/ship commands derive `[worktree]` by stripping
-   `/docs/prompts/tasks/...` from the task-folder argument, and read/write only inside it.
+2. **Argument guard** — opens by requiring its argument and printing a usage line when empty.
+   The argument is the task folder as a `@`-mention relative to the worktree
+   (`@docs/prompts/tasks/issue-<id>-<slug>`) for the phase/commit/ship commands;
+   `jli-git-setup` takes an issue number; `jli-git-cleanup` takes a worktree name/path.
+3. **Run location** — phase/commit/ship commands run from inside the feature worktree and
+   treat the task-folder argument as relative to it (no path derivation). `jli-git-setup`
+   and `jli-git-cleanup` run from the `develop` worktree.
 4. **Status-line contract** — any artifact it writes still ends with its required status line
    as the last line.
 5. **Next hint** — ends with a hint block covering the happy-path successor and any

--- a/AGENT-COMMAND-MIGRATION.md
+++ b/AGENT-COMMAND-MIGRATION.md
@@ -12,44 +12,64 @@ easily and left the human no natural place to intervene between phases. The manu
 fixes both: each command is a single, stateless step the human runs by hand, with a `/clear`
 allowed between any two steps to keep context small.
 
+## Worktree layout and run location
+
+The repo uses one bare repo with sibling worktrees under a shared parent:
+
+```
+<parent>/<repo-name>.git              <- bare repo
+<parent>/<repo-name>-develop          <- develop worktree
+<parent>/<repo-name>_<type>-<slug>    <- a feature worktree
+```
+
+`/jli-git-setup` and `/jli-git-cleanup` run from the **develop worktree**. Every other
+command runs from inside the **feature worktree** — you open it in its own editor window
+(`code <worktree>`) after setup, and all later commands run in that window.
+
 ## How state flows
 
-All state lives in the task folder under the worktree:
-`<worktree>/docs/prompts/tasks/issue-<id>-<slug>/`. Each command reads the artifacts written
-by earlier commands and writes its own. Because every command takes the **absolute
-task-folder path as a required argument**, it can rebuild everything it needs from disk after
-a `/clear` — the worktree root is derived by stripping `/docs/prompts/tasks/...` from the
-argument. `/jli-git-setup` prints that path; paste the same path into every later command.
+All state lives in the task folder under the feature worktree:
+`docs/prompts/tasks/issue-<id>-<slug>/`. Each command reads the artifacts written by earlier
+commands and writes its own. Because the phase/commit/ship commands run *inside* the feature
+worktree, the task folder is a simple relative path — you pass it as a `@`-mention
+(`@docs/prompts/tasks/issue-<id>-<slug>`), never an absolute path. The argument is required on
+every command, so each one rebuilds what it needs from disk after a `/clear`.
 
 The **specification phase is the input exception**: `/jli-spec` reads the `README.md` request
 created by `/jli-git-setup` rather than a prior pipeline artifact.
 
 ## Command ↔ agent mapping
 
-| Command | Replaces (agent) |
-|---|---|
-| `/jli-git-setup <issue-num + title>` | `agent-4-git` Tasks 1–2 (fetch + worktree) |
-| `/jli-spec <task-folder>` | `agent-1-specs` |
-| `/jli-security <task-folder>` | `agent-5-security` |
-| `/jli-test-write <task-folder> [pass]` | `agent-3-test-writer` (pass 1 and pass 2) |
-| `/jli-code <task-folder>` | `agent-2-coder` |
-| `/jli-review <task-folder>` | `agent-6-reviewer` |
-| `/jli-test-run <task-folder>` | `agent-3-test-runner` |
-| `/jli-git-commit <task-folder>` | `agent-4-git` commit tasks (3 / 3.5 / 3.7 / 4 / 5-commit) |
-| `/jli-git-ship <task-folder>` | `agent-4-git` Tasks 5-push / 6 / 7 / 8 (push, PR, merge, cleanup) |
+| Command | Runs from | Replaces (agent) |
+|---|---|---|
+| `/jli-git-setup <issue-num + title>` | develop | `agent-4-git` Tasks 1–2 (fetch + worktree) |
+| `/jli-spec @<task-folder>` | feature worktree | `agent-1-specs` |
+| `/jli-security @<task-folder>` | feature worktree | `agent-5-security` |
+| `/jli-test-write @<task-folder> [pass]` | feature worktree | `agent-3-test-writer` (pass 1 and 2) |
+| `/jli-code @<task-folder>` | feature worktree | `agent-2-coder` |
+| `/jli-review @<task-folder>` | feature worktree | `agent-6-reviewer` |
+| `/jli-test-run @<task-folder>` | feature worktree | `agent-3-test-runner` |
+| `/jli-git-commit @<task-folder>` | feature worktree | `agent-4-git` commit tasks (3 / 3.5 / 3.7 / 4 / 5-commit) |
+| `/jli-git-ship @<task-folder>` | feature worktree | `agent-4-git` Tasks 5-push / 6 / 7 (push, PR, merge) |
+| `/jli-git-cleanup <worktree>` | develop | `agent-4-git` Task 8 (worktree cleanup + refresh develop) |
 
 `agent-0-orchestrator` is **dissolved** into the "Next" hint at the end of each command — no
 command replaces it. `agent-7-pipeline-maintainer` is unchanged; it is still reached via the
 existing `/fix-pipeline` skill.
 
-`agent-4-git`'s three responsibilities were split into three commands (`setup`, `commit`,
-`ship`) so each step does one thing. Commits are their own step (`/jli-git-commit`) rather
-than being folded into the phase commands.
+`agent-4-git`'s responsibilities were split into four commands — `setup` (bootstrap),
+`commit` (its own step between phases), `ship` (push + PR + merge), and `cleanup` (worktree
+removal + refresh develop). `cleanup` is separate because it cannot run from inside the
+worktree it removes.
 
 ## The chain
 
 ```
+[develop worktree]
 /jli-git-setup
+  → code <worktree>        (open the feature worktree; everything below runs there)
+
+[feature worktree]
   → /jli-spec        → /jli-git-commit
   → /jli-security    → /jli-git-commit
   → /jli-test-write  → /jli-git-commit      (pass 1: writes test-cases.md)
@@ -57,7 +77,10 @@ than being folded into the phase commands.
   → /jli-review      → /jli-git-commit
   → /jli-test-write  → /jli-git-commit      (pass 2: writes *.spec.ts)
   → /jli-test-run    → /jli-git-commit
-  → /jli-git-ship
+  → /jli-git-ship          (push + PR + merge)
+
+[back in develop worktree]
+  → /jli-git-cleanup <worktree>
 ```
 
 Loop-backs (each command's hint states the branch it took):
@@ -93,7 +116,7 @@ Two maintenance commands, by target:
 
 - `/jli-tweak-command-chain <change>` — edits the **active chain only**: the
   `.claude/commands/jli-*.md` files and this document. It preserves the chain invariants
-  (self-containment, argument guard, worktree derivation, status-line contract, Next hint)
+  (self-containment, argument guard, run location, status-line contract, Next hint)
   and keeps the diagram/mapping here in sync.
 - `/fix-pipeline <issue>` — maintains the **deprecated** orchestrator-era agents (now under
   `.claude/deprecated-agents/`) and the `CLAUDE*.md` instructions.

--- a/scripts/deprecated-pipeline/fetch-origin.sh
+++ b/scripts/deprecated-pipeline/fetch-origin.sh
@@ -6,26 +6,22 @@
 # Ensures the bare repo has `origin` configured with the correct fetch
 # refspec, then fetches all remote refs.
 #
-# The bare repo is discovered with `git rev-parse --git-common-dir` from
-# this script's own worktree, so folder names are never hardcoded.
+# <bare-repo-path> defaults to the parent of the worktree that contains
+# this script (i.e. `..` relative to `develop/`), which is correct for
+# all standard pipeline worktrees.
 #
 # Called automatically by worktree-create.sh. Run standalone when only
-# a fetch is needed.
+# a fetch is needed (e.g. Task 1 without Task 2).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DEFAULT_BARE="$(cd "$SCRIPT_DIR" && cd "$(git rev-parse --git-common-dir)" && pwd)"
+DEFAULT_BARE="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 BARE_REPO="${1:-$DEFAULT_BARE}"
 
-# Ensure origin remote exists; if not, infer the URL from the develop worktree.
+# Ensure origin remote exists
 if ! git -C "$BARE_REPO" remote get-url origin &>/dev/null; then
-  DEVELOP="$(git -C "$BARE_REPO" worktree list --porcelain \
-    | awk '/^worktree /{wt=$2} /^branch refs\/heads\/develop$/{print wt; exit}')"
-  REMOTE_URL=""
-  if [ -n "$DEVELOP" ]; then
-    REMOTE_URL="$(git -C "$DEVELOP" remote get-url origin 2>/dev/null || true)"
-  fi
+  REMOTE_URL="$(cd "$BARE_REPO/develop" && git remote get-url origin 2>/dev/null || true)"
   if [ -z "$REMOTE_URL" ]; then
     echo "ERROR: origin remote not found in bare repo and could not be inferred." >&2
     echo "Run: git -C \"$BARE_REPO\" remote add origin <url>" >&2

--- a/scripts/deprecated-pipeline/pr-complete.sh
+++ b/scripts/deprecated-pipeline/pr-complete.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 PR_URL="${1:?Usage: pr-complete.sh <pr-url>}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BARE_REPO="$(cd "$SCRIPT_DIR" && cd "$(git rev-parse --git-common-dir)" && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 echo "==> Checking PR state..."
 PR_STATE="$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")"

--- a/scripts/deprecated-pipeline/pr-create.sh
+++ b/scripts/deprecated-pipeline/pr-create.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/pipeline/pr-create.sh
+#
+# Usage: bash scripts/pipeline/pr-create.sh <worktree-path> <title> <body-file>
+#
+# Pushes the current branch and opens a PR against `develop`.
+# Prints the PR URL as "PR: <url>".
+#
+# Arguments:
+#   <worktree-path>  Absolute path to the feature worktree.
+#   <title>          PR title (≤70 chars, imperative mood).
+#   <body-file>      Path to a file containing the full PR body (markdown).
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+TITLE="${2:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+BODY_FILE="${3:?Usage: pr-create.sh <worktree-path> <title> <body-file>}"
+
+BRANCH="$(git -C "$WORKTREE" branch --show-current)"
+
+echo "==> Pushing branch '${BRANCH}' to origin..."
+git -C "$WORKTREE" push origin "$BRANCH"
+
+echo "==> Creating PR..."
+PR_URL="$(cd "$WORKTREE" && gh pr create \
+  --base develop \
+  --title "$TITLE" \
+  --body-file "$BODY_FILE")"
+
+echo "PR: ${PR_URL}"

--- a/scripts/deprecated-pipeline/refresh-develop.sh
+++ b/scripts/deprecated-pipeline/refresh-develop.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# scripts/pipeline/refresh-develop.sh
+#
+# Usage: bash scripts/pipeline/refresh-develop.sh
+#
+# Fetches all remote refs and fast-forwards the develop worktree to
+# origin/develop. Call this at the end of every pipeline cycle to ensure
+# the next pipeline starts from an up-to-date base.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+DEVELOP="${BARE_REPO}/develop"
+
+echo "==> Fetching origin..."
+git -C "$BARE_REPO" fetch origin
+
+echo "==> Updating develop..."
+git -C "$DEVELOP" pull origin develop
+
+echo "==> develop is up to date."

--- a/scripts/deprecated-pipeline/worktree-cleanup.sh
+++ b/scripts/deprecated-pipeline/worktree-cleanup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/pipeline/worktree-cleanup.sh
+#
+# Usage: bash scripts/pipeline/worktree-cleanup.sh <worktree-path>
+#
+# Removes a pipeline worktree directory, prunes stale git entries, and
+# deletes the local branch. Safe to re-run if a prior attempt was partial.
+#
+# Run after pr-complete.sh (or after a manual GitHub merge/close).
+# Follow with refresh-develop.sh to fast-forward the develop worktree.
+
+set -euo pipefail
+
+WORKTREE="${1:?Usage: worktree-cleanup.sh <worktree-path>}"
+
+BARE_REPO="$(cd "$WORKTREE/.." && pwd)"
+WT_NAME="$(basename "$WORKTREE")"
+
+# Read branch name before the worktree is removed
+BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
+
+echo "==> Removing worktree '${WT_NAME}'..."
+git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true
+# If git already deregistered the entry, the directory may still exist on disk
+if [ -d "$WORKTREE" ]; then
+  rm -rf "$WORKTREE"
+fi
+
+echo "==> Pruning stale worktree entries..."
+git -C "$BARE_REPO" worktree prune
+
+if [ -n "$BRANCH" ]; then
+  echo "==> Deleting local branch '${BRANCH}'..."
+  # Use -D (force) because GitHub rebase-merge does not create a merge commit,
+  # so git never considers the local branch "fully merged".
+  git -C "$BARE_REPO" branch -D "$BRANCH" 2>/dev/null || true
+fi
+
+echo "==> Worktree '${WT_NAME}' cleaned up."

--- a/scripts/deprecated-pipeline/worktree-create.sh
+++ b/scripts/deprecated-pipeline/worktree-create.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/pipeline/worktree-create.sh
+#
+# Usage: bash scripts/pipeline/worktree-create.sh <type> <slug>
+#
+# Creates a git worktree for a new feature/fix branch, installs npm deps,
+# and prints the absolute worktree path as "Worktree: <path>".
+#
+# Works when called from any worktree (develop/, feat_*/,  ci_*/) because
+# the bare repo is always the parent directory of whichever worktree holds
+# this script.
+#
+# Prerequisites: run fetch-origin.sh before this script.
+
+set -euo pipefail
+
+TYPE="${1:?Usage: worktree-create.sh <type> <slug>}"
+SLUG="${2:?Usage: worktree-create.sh <type> <slug>}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# scripts/pipeline is 2 levels below the worktree root, which is 1 level
+# below the bare repo: <bare-repo>/<worktree>/scripts/pipeline
+BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+WT_NAME="${TYPE}_${SLUG}"
+BRANCH="${TYPE}/${SLUG}"
+WT_PATH="${BARE_REPO}/${WT_NAME}"
+
+echo "==> Creating worktree '${WT_NAME}' on branch '${BRANCH}'..."
+git -C "$BARE_REPO" worktree add "$WT_NAME" -b "$BRANCH" origin/develop
+
+echo "==> Installing npm dependencies in ${WT_PATH}..."
+(cd "$WT_PATH" && npm install --silent)
+
+echo "Worktree: ${WT_PATH}"

--- a/scripts/pipeline/fetch-origin.sh
+++ b/scripts/pipeline/fetch-origin.sh
@@ -23,10 +23,10 @@ if ! git -C "$BARE_REPO" remote get-url origin &>/dev/null; then
   DEVELOP="$(git -C "$BARE_REPO" worktree list --porcelain \
     | awk '/^worktree /{wt=$2} /^branch refs\/heads\/develop$/{print wt; exit}')"
   REMOTE_URL=""
-  if [ -n "$DEVELOP" ]; then
+  if [[ -n "$DEVELOP" ]]; then
     REMOTE_URL="$(git -C "$DEVELOP" remote get-url origin 2>/dev/null || true)"
   fi
-  if [ -z "$REMOTE_URL" ]; then
+  if [[ -z "$REMOTE_URL" ]]; then
     echo "ERROR: origin remote not found in bare repo and could not be inferred." >&2
     echo "Run: git -C \"$BARE_REPO\" remote add origin <url>" >&2
     exit 1

--- a/scripts/pipeline/pr-complete.sh
+++ b/scripts/pipeline/pr-complete.sh
@@ -20,10 +20,10 @@ BARE_REPO="$(cd "$SCRIPT_DIR" && cd "$(git rev-parse --git-common-dir)" && pwd)"
 echo "==> Checking PR state..."
 PR_STATE="$(gh pr view "$PR_URL" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")"
 
-if [ "$PR_STATE" = "MERGED" ]; then
+if [[ "$PR_STATE" == "MERGED" ]]; then
   echo "    PR already merged — nothing to do."
   exit 0
-elif [ "$PR_STATE" = "CLOSED" ]; then
+elif [[ "$PR_STATE" == "CLOSED" ]]; then
   echo "    PR is closed (not merged) — nothing to do."
   exit 0
 fi

--- a/scripts/pipeline/refresh-develop.sh
+++ b/scripts/pipeline/refresh-develop.sh
@@ -14,7 +14,7 @@ BARE_REPO="$(cd "$SCRIPT_DIR" && cd "$(git rev-parse --git-common-dir)" && pwd)"
 DEVELOP="$(git -C "$BARE_REPO" worktree list --porcelain \
   | awk '/^worktree /{wt=$2} /^branch refs\/heads\/develop$/{print wt; exit}')"
 
-if [ -z "$DEVELOP" ]; then
+if [[ -z "$DEVELOP" ]]; then
   echo "ERROR: could not locate the develop worktree." >&2
   exit 1
 fi

--- a/scripts/pipeline/refresh-develop.sh
+++ b/scripts/pipeline/refresh-develop.sh
@@ -4,19 +4,25 @@
 # Usage: bash scripts/pipeline/refresh-develop.sh
 #
 # Fetches all remote refs and fast-forwards the develop worktree to
-# origin/develop. Call this at the end of every pipeline cycle to ensure
-# the next pipeline starts from an up-to-date base.
+# origin/develop. The develop worktree is located dynamically (by branch),
+# so its folder name is never hardcoded. Run at the end of every cycle.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-DEVELOP="${BARE_REPO}/develop"
+BARE_REPO="$(cd "$SCRIPT_DIR" && cd "$(git rev-parse --git-common-dir)" && pwd)"
+DEVELOP="$(git -C "$BARE_REPO" worktree list --porcelain \
+  | awk '/^worktree /{wt=$2} /^branch refs\/heads\/develop$/{print wt; exit}')"
+
+if [ -z "$DEVELOP" ]; then
+  echo "ERROR: could not locate the develop worktree." >&2
+  exit 1
+fi
 
 echo "==> Fetching origin..."
 git -C "$BARE_REPO" fetch origin
 
-echo "==> Updating develop..."
+echo "==> Updating develop worktree at ${DEVELOP}..."
 git -C "$DEVELOP" pull origin develop
 
 echo "==> develop is up to date."

--- a/scripts/pipeline/worktree-cleanup.sh
+++ b/scripts/pipeline/worktree-cleanup.sh
@@ -34,14 +34,14 @@ BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
 
 echo "==> Removing worktree '${WT_NAME}'..."
 git -C "$BARE_REPO" worktree remove --force "$WORKTREE" 2>/dev/null || true
-if [ -d "$WORKTREE" ]; then
+if [[ -d "$WORKTREE" ]]; then
   rm -rf "$WORKTREE"
 fi
 
 echo "==> Pruning stale worktree entries..."
 git -C "$BARE_REPO" worktree prune
 
-if [ -n "$BRANCH" ]; then
+if [[ -n "$BRANCH" ]]; then
   echo "==> Deleting local branch '${BRANCH}'..."
   # Use -D (force) because GitHub rebase/squash-merge does not create a merge
   # commit, so git never considers the local branch "fully merged".

--- a/scripts/pipeline/worktree-cleanup.sh
+++ b/scripts/pipeline/worktree-cleanup.sh
@@ -1,27 +1,39 @@
 #!/usr/bin/env bash
 # scripts/pipeline/worktree-cleanup.sh
 #
-# Usage: bash scripts/pipeline/worktree-cleanup.sh <worktree-path>
+# Usage: bash scripts/pipeline/worktree-cleanup.sh <worktree>
 #
-# Removes a pipeline worktree directory, prunes stale git entries, and
-# deletes the local branch. Safe to re-run if a prior attempt was partial.
+# Removes a feature worktree, prunes stale git entries, and deletes its
+# local branch. Safe to re-run if a prior attempt was partial.
 #
-# Run after pr-complete.sh (or after a manual GitHub merge/close).
-# Follow with refresh-develop.sh to fast-forward the develop worktree.
+# <worktree> may be an absolute path OR just the worktree folder name
+# (resolved against the parent of the bare repo).
+#
+# IMPORTANT: run this from the develop worktree, never from inside the
+# worktree being removed. Follow with refresh-develop.sh.
 
 set -euo pipefail
 
-WORKTREE="${1:?Usage: worktree-cleanup.sh <worktree-path>}"
+WORKTREE_ARG="${1:?Usage: worktree-cleanup.sh <worktree>}"
 
-BARE_REPO="$(cd "$WORKTREE/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR" && cd "$(git rev-parse --git-common-dir)" && pwd)"
+WORKTREES_ROOT="$(dirname "$BARE_REPO")"
+
+# Resolve a bare folder name to a path under the worktrees root.
+case "$WORKTREE_ARG" in
+  /* | [A-Za-z]:* | */*) WORKTREE="$WORKTREE_ARG" ;;
+  *) WORKTREE="${WORKTREES_ROOT}/${WORKTREE_ARG}" ;;
+esac
+# Absolutize when the directory still exists.
+WORKTREE="$( (cd "$WORKTREE" 2>/dev/null && pwd) || echo "$WORKTREE" )"
 WT_NAME="$(basename "$WORKTREE")"
 
-# Read branch name before the worktree is removed
+# Read branch name before the worktree is removed.
 BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
 
 echo "==> Removing worktree '${WT_NAME}'..."
-git -C "$BARE_REPO" worktree remove --force "$WT_NAME" 2>/dev/null || true
-# If git already deregistered the entry, the directory may still exist on disk
+git -C "$BARE_REPO" worktree remove --force "$WORKTREE" 2>/dev/null || true
 if [ -d "$WORKTREE" ]; then
   rm -rf "$WORKTREE"
 fi
@@ -31,8 +43,8 @@ git -C "$BARE_REPO" worktree prune
 
 if [ -n "$BRANCH" ]; then
   echo "==> Deleting local branch '${BRANCH}'..."
-  # Use -D (force) because GitHub rebase-merge does not create a merge commit,
-  # so git never considers the local branch "fully merged".
+  # Use -D (force) because GitHub rebase/squash-merge does not create a merge
+  # commit, so git never considers the local branch "fully merged".
   git -C "$BARE_REPO" branch -D "$BRANCH" 2>/dev/null || true
 fi
 

--- a/scripts/pipeline/worktree-create.sh
+++ b/scripts/pipeline/worktree-create.sh
@@ -6,9 +6,15 @@
 # Creates a git worktree for a new feature/fix branch, installs npm deps,
 # and prints the absolute worktree path as "Worktree: <path>".
 #
-# Works when called from any worktree (develop/, feat_*/,  ci_*/) because
-# the bare repo is always the parent directory of whichever worktree holds
-# this script.
+# Layout (isolated worktree): the bare repo and every worktree are siblings
+# under one parent folder. The bare repo is discovered with
+# `git rev-parse --git-common-dir`, so folder names are never hardcoded.
+#
+#   <parent>/<repo-name>.git              <- bare repo
+#   <parent>/<repo-name>-develop          <- develop worktree (runs this script)
+#   <parent>/<repo-name>_<type>-<slug>    <- worktree this script creates
+#
+# Branch is `<type>/<slug>`; the worktree folder is `<repo-name>_<type>-<slug>`.
 #
 # Prerequisites: run fetch-origin.sh before this script.
 
@@ -18,16 +24,17 @@ TYPE="${1:?Usage: worktree-create.sh <type> <slug>}"
 SLUG="${2:?Usage: worktree-create.sh <type> <slug>}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# scripts/pipeline is 2 levels below the worktree root, which is 1 level
-# below the bare repo: <bare-repo>/<worktree>/scripts/pipeline
-BARE_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BARE_REPO="$(cd "$SCRIPT_DIR" && cd "$(git rev-parse --git-common-dir)" && pwd)"
+WORKTREES_ROOT="$(dirname "$BARE_REPO")"
+REPO_NAME="$(basename "$BARE_REPO" .git)"
 
-WT_NAME="${TYPE}_${SLUG}"
+WT_SLUG="${TYPE}-${SLUG}"
+WT_NAME="${REPO_NAME}_${WT_SLUG}"
 BRANCH="${TYPE}/${SLUG}"
-WT_PATH="${BARE_REPO}/${WT_NAME}"
+WT_PATH="${WORKTREES_ROOT}/${WT_NAME}"
 
 echo "==> Creating worktree '${WT_NAME}' on branch '${BRANCH}'..."
-git -C "$BARE_REPO" worktree add "$WT_NAME" -b "$BRANCH" origin/develop
+git -C "$BARE_REPO" worktree add "$WT_PATH" -b "$BRANCH" origin/develop
 
 echo "==> Installing npm dependencies in ${WT_PATH}..."
 (cd "$WT_PATH" && npm install --silent)


### PR DESCRIPTION
## Summary

Fixes the pipeline bootstrap scripts for the **sibling worktree layout** (bare repo and worktrees share one parent), and reworks the `jli-` command chain to run inside the feature worktree.

## Script fix (closes #115)

- Discover the bare repo with `git rev-parse --git-common-dir` instead of a fixed `$SCRIPT_DIR/../../..` climb — works for nested *and* sibling layouts.
- Locate the `develop` worktree dynamically by branch (`git worktree list --porcelain`), not by assuming a folder named `develop`.
- Set `remote.origin.fetch` before fetching so `origin/develop` resolves.
- Create worktrees as `<repo-name>_<type>-<slug>` (branch stays `<type>/<slug>`).
- `worktree-cleanup.sh` accepts a bare folder name or an absolute path.
- Originals preserved under `scripts/deprecated-pipeline/`.

## Chain UX changes

- After `/jli-git-setup` (run from develop), open the feature worktree (`code <worktree>`) and run every phase command there with a `@`-mention relative task folder — no more pasting absolute paths.
- Dropped all `cd [worktree]` from the commands (they run from cwd).
- New `/jli-git-cleanup <worktree>` runs from develop after merge (can't remove the worktree you're standing in). `/jli-git-ship` now does push + PR + merge only.
- Updated `AGENT-COMMAND-MIGRATION.md` (layout, state model, mapping, chain diagram) and the `jli-tweak-command-chain` invariants.

## Test plan

- [x] `bash -n` passes on all 6 `scripts/pipeline/*.sh`
- [x] Layout discovery verified live: `BARE_REPO`, `WORKTREES_ROOT`, `REPO_NAME`, and develop-worktree resolution all correct on the real sibling layout
- [ ] `/jli-git-setup` creates `SocialMediaPublisherApp_<type>-<slug>` and the task folder
- [ ] Phase commands run from the opened worktree with `@docs/prompts/tasks/...`
- [ ] `/jli-git-cleanup` removes the worktree and refreshes develop from the develop window

🤖 Generated with [Claude Code](https://claude.com/claude-code)
