### PR TITLE
fix(pipeline): delete local branch when worktree is prunable

### DIFF
--- a/scripts/pipeline/worktree-cleanup.sh
+++ b/scripts/pipeline/worktree-cleanup.sh
@@ -29,8 +29,17 @@ esac
 WORKTREE="$( (cd "$WORKTREE" 2>/dev/null && pwd) || echo "$WORKTREE" )"
 WT_NAME="$(basename "$WORKTREE")"
 
-# Read branch name before the worktree is removed.
-BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
+# Read the branch name BEFORE the worktree is removed. Prefer the worktree
+# metadata from `worktree list`, which still reports the branch even when the
+# working directory is already gone (a 'prunable' worktree). Fall back to
+# reading it from inside the worktree if metadata has no branch (e.g. detached).
+BRANCH="$(git -C "$BARE_REPO" worktree list --porcelain | awk -v name="$WT_NAME" '
+  /^worktree / { wt = substr($0, 10); sub(/.*\//, "", wt); is_match = (wt == name) }
+  is_match && /^branch / { br = substr($0, 8); sub(/^refs\/heads\//, "", br); print br; exit }
+')"
+if [[ -z "$BRANCH" ]]; then
+  BRANCH="$(git -C "$WORKTREE" branch --show-current 2>/dev/null || true)"
+fi
 
 echo "==> Removing worktree '${WT_NAME}'..."
 git -C "$BARE_REPO" worktree remove --force "$WORKTREE" 2>/dev/null || true


### PR DESCRIPTION
## Summary

`worktree-cleanup.sh` read the branch name from *inside* the worktree via `git -C "$WORKTREE" branch --show-current`. When a worktree is already `prunable` (its working directory removed), that read returns empty, so `BRANCH` was empty and the `git branch -D` block was silently skipped — leaving the merged local branch behind.

This was observed during `/jli-git-cleanup` of `fix_intro-list-extraction`: the worktree was removed but the local branch had to be deleted manually.

## Fix

- Read the branch from `git worktree list --porcelain`, which still reports the branch for prunable worktrees.
- Keep the in-worktree `branch --show-current` read as a fallback for detached-HEAD cases.

## Testing

- `bash -n` syntax check passes.
- awk parser verified against sample porcelain output for a prunable worktree — correctly extracts `fix/intro-list-extraction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)