### PR TITLE
fix(lint): repair eslint flat config and resolve violations (#126)

### DIFF
--- a/docs/prompts/tasks/issue-126-lint-eslint-config/README.md
+++ b/docs/prompts/tasks/issue-126-lint-eslint-config/README.md
@@ -1,0 +1,21 @@
+Worktree: /e/Git/GitHub/SocialMediaPublisherApp_fix-lint-eslint-config
+
+# Issue #126: Problem with linting and eslintconfig
+
+- Author: @JeremieLitzler
+- URL: https://github.com/JeremieLitzler/SocialMediaPublisherApp/issues/126
+
+## Feature request (issue body)
+
+First, `rtk lint` doesn't work. Error message: `rtk lint couldn't locate the eslint binary directly. Let me run the project's lint script, and confirm whether the type-check error pre-exists my changes.`
+
+Second, the lint failure is an environment/tooling issue (ESLint 9.39.2 cannot load its flat config under this Node — a SyntaxError before any file is linted), affecting both `rtk lint` and `npm run lint` regardless of code.
+
+```
+> eslint . --fix
+Oops! Something went wrong! :(
+ESLint: 9.39.2
+SyntaxError: Unexpected token ':'
+    at compileSourceTextModule (node:internal/modules/esm/utils:318:16)
+    ...
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-import pluginVue, { rules } from 'eslint-plugin-vue'
+import pluginVue from 'eslint-plugin-vue'
 import vueTsEslintConfig from '@vue/eslint-config-typescript'
 import skipFormatting from '@vue/eslint-config-prettier/skip-formatting'
 
@@ -16,7 +16,26 @@ export default [
   ...pluginVue.configs['flat/essential'],
   ...vueTsEslintConfig(),
   skipFormatting,
-  rules: {
-    'vue/multi-word-component-names': 0
-  }
+  {
+    name: 'app/rules',
+    rules: {
+      'vue/multi-word-component-names': 0,
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
+    name: 'app/test-overrides',
+    files: ['**/*.{test,spec}.{ts,tsx}'],
+    rules: {
+      // Test mocks legitimately use `any` for partial fixtures and stubs.
+      '@typescript-eslint/no-explicit-any': 'off',
+    },
+  },
 ]

--- a/netlify/functions/fetch-article.ts
+++ b/netlify/functions/fetch-article.ts
@@ -10,7 +10,7 @@ interface FetchArticleResponse {
 
 export const handler: Handler = async (
   event: HandlerEvent,
-  context: HandlerContext
+  _context: HandlerContext
 ) => {
   // Only allow GET requests
   if (event.httpMethod !== 'GET') {
@@ -34,7 +34,7 @@ export const handler: Handler = async (
   let urlObj: URL
   try {
     urlObj = new URL(url)
-  } catch (error) {
+  } catch {
     return {
       statusCode: 400,
       body: JSON.stringify({ success: false, error: 'Invalid URL format' }),

--- a/src/components/AppLink.vue
+++ b/src/components/AppLink.vue
@@ -22,7 +22,7 @@ interface AnchorLink {
   to?: string
 }
 // By default, the `to` property is a string with a default
-const { to = '#link-not-set', ...props } = defineProps<RouterLinkProps | AnchorLink>()
+const { to = '#link-not-set' } = defineProps<RouterLinkProps | AnchorLink>()
 const isExternal = computed(() => {
   // If we have a link that is inferred by Unplugin VueRouter, the type of `to` is object
   // RouteLocationAsRelativeTyped<RouteNamedMap, "/"> | RouteLocationAsRelativeTyped<RouteNamedMap, "/[...catchAll]"> | ... 9 more ... | RouteLocationAsPathTyped<...>

--- a/src/components/AppLoader.vue
+++ b/src/components/AppLoader.vue
@@ -5,7 +5,7 @@ const {
 </script>
 
 <template>
-  <div>
+  <div :class="cssClass">
     <!-- <iconify-icon icon="lucide:loader-circle" class="text-6xl animate-spin" /> -->
     <p>Loading...</p>
   </div>

--- a/src/components/AppToolTip.vue
+++ b/src/components/AppToolTip.vue
@@ -7,7 +7,6 @@ const { toolTipText = 'Click the status icon to toggle the value', showToolTip =
 
 const displayTooltip = ref(false)
 const tooltipIcon = useTemplateRef('tooltip-icon')
-const tooltipParagraph = useTemplateRef('tooltip-paragraph')
 const tooltipPosition = ref({ top: 0, left: 0 })
 
 const toggleTooltip = (dismiss: boolean = false) => {

--- a/src/components/article/ArticleInput.spec.ts
+++ b/src/components/article/ArticleInput.spec.ts
@@ -25,7 +25,7 @@ const globalStubs = {
   Button: { template: '<button v-bind="$attrs"><slot /></button>' },
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 let extractionState: any
 
 function mountInput() {

--- a/src/components/article/ManualIntroduction.spec.ts
+++ b/src/components/article/ManualIntroduction.spec.ts
@@ -38,7 +38,7 @@ function makeArticle() {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ 
 function mountFallback(overrides: Record<string, any>) {
   const extractionState = ref<ExtractionState>({
     status: 'missing-introduction',

--- a/src/components/ui/button/Button.vue
+++ b/src/components/ui/button/Button.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
 import { cn } from '@/lib/utils'
-import { Primitive, type PrimitiveProps } from 'radix-vue'
 import { type ButtonVariants, buttonVariants } from '.'
 
 interface Props {

--- a/src/components/ui/card/CardTitle.vue
+++ b/src/components/ui/card/CardTitle.vue
@@ -11,8 +11,8 @@ const props = defineProps<{
 <template>
   <AppHeading heading-type="h1" v-if="props.isPageTitle" :class="cn('sfc-card-title', props.class)">
     <slot />
-  </AppHeading heading-type="h1">
+  </AppHeading>
   <AppHeading heading-type="h3" v-else :class="cn('sfc-card-title', props.class)">
     <slot />
-  </AppHeading heading-type="h3">
+  </AppHeading>
 </template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,6 +6,6 @@ const router = createRouter({
   routes,
 })
 
-router.beforeEach(async (to, _from) => {})
+router.beforeEach(async (_to, _from) => {})
 
 export default router

--- a/src/types/LinkProp.ts
+++ b/src/types/LinkProp.ts
@@ -3,7 +3,7 @@ import type { SideBarActionsEnum } from './SideBarActionsEnum'
 export interface LinkProp {
   to?: string
   action?: SideBarActionsEnum
-  icon: Object
+  icon: object
   label: string
   cssClass?: string
 }

--- a/src/utils/htmlExtractor.test.ts
+++ b/src/utils/htmlExtractor.test.ts
@@ -19,7 +19,6 @@ describe('htmlExtractor', () => {
   let englishWithIntroDoc: Document
   let frenchWithIntroDoc: Document
   let englishNoCreditDoc: Document
-  let frenchNoCreditDoc: Document
   let englishNoH2Doc: Document
   let organizingSpecificationsDoc: Document
 
@@ -44,12 +43,6 @@ describe('htmlExtractor', () => {
       'utf-8'
     )
     englishNoCreditDoc = new JSDOM(englishNoCreditHtml).window.document
-
-    const frenchNoCreditHtml = readFileSync(
-      join(fixturesPath, 'french-no-credit.html'),
-      'utf-8'
-    )
-    frenchNoCreditDoc = new JSDOM(frenchNoCreditHtml).window.document
 
     // Create a version without h2 for testing null return
     const htmlWithoutH2 = englishWithIntroHtml.replace(/<h2[^>]*>.*?<\/h2>/gs, '')

--- a/src/utils/utm.ts
+++ b/src/utils/utm.ts
@@ -39,7 +39,7 @@ export function generateUTMLink(url: string, platform: Platform): string {
     urlObj.searchParams.set('utm_source', platform)
 
     return urlObj.toString()
-  } catch (error) {
+  } catch {
     // If URL parsing fails, fall back to simple string append
     // This shouldn't happen in normal use but provides graceful degradation
     const separator = url.includes('?') ? '&' : '?'


### PR DESCRIPTION
## Summary

Fixes #126. `rtk lint` / `npm run lint` crashed with `SyntaxError: Unexpected token ':'` before linting any file.

- **Root cause:** `eslint.config.js` had `rules:` written as a bare property inside the `export default [ ]` array — invalid JS. Wrapped it in a proper config object and removed the unused `{ rules }` named import.
- **Config:** added `^_` ignore patterns for `no-unused-vars` (intentional throwaway bindings in shadcn components/tests) and disabled `no-explicit-any` for test files only (test mocks).
- **Code cleanup:** removed dead code (unused imports, refs, params, catch bindings, unused test fixture) and fixed invalid closing tags in `CardTitle.vue` (`</AppHeading heading-type="h1">` → `</AppHeading>`).
- **Behavior note:** `AppLoader.vue` now binds its `cssClass` prop to the wrapper div (was declared but never applied).

## Verification

- `npm run lint` — clean
- `npm run type-check` — passes
- `npx vitest run` — 379 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)